### PR TITLE
Fix fail to destroy

### DIFF
--- a/infrastructure/terragrunt.hcl
+++ b/infrastructure/terragrunt.hcl
@@ -57,6 +57,9 @@ generate "provider" {
   contents  = <<EOF
 provider "azurerm" {
   features {
+    resource_group {
+│     prevent_deletion_if_contains_resources = false
+│   }
     key_vault {
       # Don't purge on destroy (this would fail due to purge protection being enabled on keyvault)
       purge_soft_delete_on_destroy               = false

--- a/infrastructure/terragrunt.hcl
+++ b/infrastructure/terragrunt.hcl
@@ -58,8 +58,8 @@ generate "provider" {
 provider "azurerm" {
   features {
     resource_group {
-│     prevent_deletion_if_contains_resources = false
-│   }
+      prevent_deletion_if_contains_resources = false
+    }
     key_vault {
       # Don't purge on destroy (this would fail due to purge protection being enabled on keyvault)
       purge_soft_delete_on_destroy               = false


### PR DESCRIPTION
Fixes occasional AML lagging resource destruction interrupting `make destroy`.

Resolves #7 