### PR TITLE
Always set subscription ID

### DIFF
--- a/scripts/az_login.sh
+++ b/scripts/az_login.sh
@@ -19,8 +19,9 @@ set -o nounset
 
 if [ -n "${TF_IN_AUTOMATION:-}" ]; then
     az login --service-principal -u "$ARM_CLIENT_ID" -p "$ARM_CLIENT_SECRET" --tenant "$ARM_TENANT_ID"
-    az account set -s "$ARM_SUBSCRIPTION_ID"
 fi
+
+az account set -s "$ARM_SUBSCRIPTION_ID"
 
 SUB_NAME=$(az account show --query name -o tsv)
 SUB_ID=$(az account show --query id -o tsv)


### PR DESCRIPTION
I found that the Azure account subscription ID wasn't being set when I build my dev environment.

This change ensures that the account subscription ID is always set even when `TF_IN_AUTOMATION` is not true.