### PR TITLE
Provision per-app gh resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Local .terraform directories
 **/.terraform/*
-.terraform.lock.hcl
 
 # .tfstate files
 *.tfstate

--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,8 @@ destroy-no-terraform: az-login ## Destroy all resource groups associated with th
 clean: ## Remove all local terraform state
 	find ${MAKEFILE_DIR} -type d -name ".terraform" -exec rm -rf "{}" \;
 
-tf-init: az-login ## Init Terraform (use for updating lock files)
+tf-init: az-login ## Init Terraform (use for updating lock files in the case of a conflict)
 	$(call target_title, "Terraform init") \
 	&& . ${MAKEFILE_DIR}/scripts/load_env.sh \
 	&& cd ${MAKEFILE_DIR} \
-	&& terragrunt run-all init
+	&& terragrunt run-all init -upgrade

--- a/Makefile
+++ b/Makefile
@@ -96,16 +96,27 @@ apps: bootstrap ## Deploy FlowEHR apps
 	&& cd ${MAKEFILE_DIR}/apps \
 	&& terragrunt run-all apply --terragrunt-include-external-dependencies --terragrunt-non-interactive
 
-destroy: az-login ## Destroy all infrastructure
+destroy: az-login ## Destroy all
 	$(call target_title, "Destroy All") \
 	&& . ${MAKEFILE_DIR}/scripts/load_env.sh \
-	&& cd ${MAKEFILE_DIR}/infrastructure \
 	&& terragrunt run-all destroy --terragrunt-non-interactive
 
 destroy-no-terraform: az-login ## Destroy all resource groups associated with this deployment
 	$(call target_title, "Destroy no terraform") \
 	&& . ${MAKEFILE_DIR}/scripts/load_env.sh \
 	&& . ${MAKEFILE_DIR}/scripts/destroy_no_terraform.sh
+
+destroy-infrastructure: az-login ## Destroy infrastructure
+	$(call target_title, "Destroy Infrastructure") \
+	&& . ${MAKEFILE_DIR}/scripts/load_env.sh \
+	&& cd ${MAKEFILE_DIR}/infrastructure \
+	&& terragrunt run-all destroy --terragrunt-non-interactive
+
+destroy-apps: az-login ## Destroy apps
+	$(call target_title, "Destroy Apps") \
+	&& . ${MAKEFILE_DIR}/scripts/load_env.sh \
+	&& cd ${MAKEFILE_DIR}/apps \
+	&& terragrunt run-all destroy --terragrunt-non-interactive
 
 clean: ## Remove all local terraform state
 	find ${MAKEFILE_DIR} -type d -name ".terraform" -exec rm -rf "{}" \;

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ For the full reference of possible configuration values, see the [config schema 
     make all
     ```
 
+    > For more info on configuring and deploying apps, see the [README](./apps/README.md)
+
     Alternatively, you can deploy just infrastructure:
 
     ```bash

--- a/apps/.terraform.lock.hcl
+++ b/apps/.terraform.lock.hcl
@@ -1,0 +1,65 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.45.0"
+  constraints = ">= 3.32.0"
+  hashes = [
+    "h1:WupjURkT1JPNBRzKmrSsD1Y8zhuQnL3ctKBpNLZBsLA=",
+    "zh:04c5dbb8845366ce5eb0dc2d55e151270cc2c0ace20993867fdae9af43b953ad",
+    "zh:2589585da615ccae341400d45d672ee3fae413fdd88449b5befeff12a85a44b2",
+    "zh:603869ed98fff5d9bf841a51afd9e06b628533c59356c8433aef4b15df63f5f7",
+    "zh:853fecab9c987b6772c8d9aa10362675f6c626b60ebc7118aa33ce91366fcc38",
+    "zh:979848c45e8e058862c36ba3a661457f7c81ef26ebb6634f479600de9c203d65",
+    "zh:9b512c8588ecc9c1b803b746a3a8517422561a918f0dfb0faaa707ed53ef1760",
+    "zh:a9601ffb58043426bcff1220662d6d137f0b2857a24f2dcf180aeac2c9cea688",
+    "zh:d52d2652328f0ed3ba202561d88cb9f43c174edbfaab1abf69f772125dbfe15e",
+    "zh:d92d91ca597c47f575bf3ae129f4b723be9b7dcb71b906ec6ec740fac29b1aaa",
+    "zh:ded73b730e4197b70fda9e83447c119f92f75dc37be3ff2ed45730c8f0348c28",
+    "zh:ec37ac332d50f8ca5827f97198346b0f8ecbf470e2e3ba1e027bb389d826b902",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/github" {
+  version = "5.18.0"
+  hashes = [
+    "h1:wiTbHC7qXZV6UPB8RZlGzdMVh5xm4tVI09h05Lj/DVQ=",
+    "zh:2030909af32ef42493e1bcc09ed27b77fc7e93b902ff3f78f92877176cb75ad2",
+    "zh:390f253ae743dfb818334ff669ed45e10f90b9758a5e8c71a3699cac54a781f8",
+    "zh:3d7c694648dad729ae8c48173c300c10fedbf55dc29525b94fab78dcfebe727f",
+    "zh:46c0ea383516b85ecc40e1e1b9ab974d03c94305bc3fd570b493a00736ff3929",
+    "zh:4df27856b9553d1c240b24e759da79ac305611fed9368a527fb6e5d2ba7cdb32",
+    "zh:757ac517a58098324b7ecff48bee55bc7648558ae45198080ee00215414ab70a",
+    "zh:7cd9c92e44252b5b7794eb98fad41fc51f1ce5119899cc450fd60c36964c4aca",
+    "zh:a69ec9db536f6ffc2e45324cd4c8133a18f3d0f8e266a531d2ef07a0da5de9c9",
+    "zh:aad0d3d19c10c6373c00bc29a93932601129ed0927d76068f90073f7df851735",
+    "zh:b00c4933fa091420af7f149d4c6bb2348a87dadc16d1474a1dfd4e435fbdec49",
+    "zh:d6dd1e6e3c42ef76006c24db662d90ca6e623e543fa924db2c49185ec98a9f57",
+    "zh:e0e60989b84f52db929eb12952a5971dec78efbad9f6d74fd7dfd95127833c0d",
+    "zh:e925a155a07a982c731e7deec5e0acb419fd6c5ab2d1666af5395386a1e9c0fe",
+    "zh:eb9b833594a585f22142dfc624416104c66eaafef8ddd6298d23a528896eeb6e",
+  ]
+}
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "5.18.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:wiTbHC7qXZV6UPB8RZlGzdMVh5xm4tVI09h05Lj/DVQ=",
+    "zh:2030909af32ef42493e1bcc09ed27b77fc7e93b902ff3f78f92877176cb75ad2",
+    "zh:390f253ae743dfb818334ff669ed45e10f90b9758a5e8c71a3699cac54a781f8",
+    "zh:3d7c694648dad729ae8c48173c300c10fedbf55dc29525b94fab78dcfebe727f",
+    "zh:46c0ea383516b85ecc40e1e1b9ab974d03c94305bc3fd570b493a00736ff3929",
+    "zh:4df27856b9553d1c240b24e759da79ac305611fed9368a527fb6e5d2ba7cdb32",
+    "zh:757ac517a58098324b7ecff48bee55bc7648558ae45198080ee00215414ab70a",
+    "zh:7cd9c92e44252b5b7794eb98fad41fc51f1ce5119899cc450fd60c36964c4aca",
+    "zh:a69ec9db536f6ffc2e45324cd4c8133a18f3d0f8e266a531d2ef07a0da5de9c9",
+    "zh:aad0d3d19c10c6373c00bc29a93932601129ed0927d76068f90073f7df851735",
+    "zh:b00c4933fa091420af7f149d4c6bb2348a87dadc16d1474a1dfd4e435fbdec49",
+    "zh:d6dd1e6e3c42ef76006c24db662d90ca6e623e543fa924db2c49185ec98a9f57",
+    "zh:e0e60989b84f52db929eb12952a5971dec78efbad9f6d74fd7dfd95127833c0d",
+    "zh:e925a155a07a982c731e7deec5e0acb419fd6c5ab2d1666af5395386a1e9c0fe",
+    "zh:eb9b833594a585f22142dfc624416104c66eaafef8ddd6298d23a528896eeb6e",
+  ]
+}

--- a/apps/README.md
+++ b/apps/README.md
@@ -10,23 +10,15 @@ For FlowEHR to create and manage repositories for FlowEHR Apps, it needs a [GitH
 
 > You will need the appropriate permissions to create PATs in the scope of your organisation.
 
-Follow the instructions [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-fine-grained-personal-access-token) to create a fine-grained token. For `Resource owner`, select the appropriate GitHub organisation which will contain the repositories created by FlowEHR (or select yourself if desired).
+Follow the instructions [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#personal-access-tokens-classic) to create a classic token (fine-grained tokens don't currently support the GitHub GraphQL API which we require).
 
 Then, make sure you have enabled the following permissions:
 
-#### Repository permissions
+- `repo`
+- `write:org`
+- `delete_repo`
 
-- `Administration`: `Read and write`
-- `Environments`: `Read and write`
-- `Metadata`: `Read`
-- `Secrets`: `Read and write`
-- `Variables`: `Read and write`
-
-#### Organisation permissions
-
-- `Members`: `Read and write`
-
-When ready, click `Generate` and copy the token. Paste it into the `gh_token` field in your `config.yaml`.
+When ready, click `Generate` and copy the token. Paste it into the `github_token` field in your `config.yaml`.
 
 ### Deploy apps
 

--- a/apps/README.md
+++ b/apps/README.md
@@ -4,6 +4,32 @@ This directory contains the code for deploying and hosting apps that present and
 
 ## Getting started
 
+### Configure GitHub permissions
+
+For FlowEHR to create and manage repositories for FlowEHR Apps, it needs a [GitHub Personal Access Token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) to be set in your `config.yaml` in the root of the repo.
+
+> You will need the appropriate permissions to create PATs in the scope of your organisation.
+
+Follow the instructions [here](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-fine-grained-personal-access-token) to create a fine-grained token. For `Resource owner`, select the appropriate GitHub organisation which will contain the repositories created by FlowEHR (or select yourself if desired).
+
+Then, make sure you have enabled the following permissions:
+
+#### Repository permissions
+
+- `Administration`: `Read and write`
+- `Environments`: `Read and write`
+- `Metadata`: `Read`
+- `Secrets`: `Read and write`
+- `Variables`: `Read and write`
+
+#### Organisation permissions
+
+- `Members`: `Read and write`
+
+When ready, click `Generate` and copy the token. Paste it into the `gh_token` field in your `config.yaml`.
+
+### Deploy apps
+
 1. First, to configure which apps you'd like to deploy, copy the `apps.sample.yaml` to a new `apps.yaml` file:
 
 ```bash

--- a/apps/app/platform.tf
+++ b/apps/app/platform.tf
@@ -46,6 +46,7 @@ resource "azurerm_linux_web_app" "app" {
     DOCKER_ENABLE_CI                           = true
     COSMOS_STATE_STORE_ENDPOINT                = data.azurerm_cosmosdb_account.state_store.endpoint
     FEATURE_STORE_CONNECTION_STRING            = local.feature_store_odbc
+    ENVIRONMENT                                = var.environment
   })
 
   identity {

--- a/apps/app/repository.tf
+++ b/apps/app/repository.tf
@@ -95,7 +95,7 @@ resource "github_branch_protection" "deployment" {
 
   required_status_checks {
     strict   = true
-    contexts = ["lint"]
+    contexts = ["Lint"]
   }
 
   required_pull_request_reviews {

--- a/apps/app/repository.tf
+++ b/apps/app/repository.tf
@@ -56,6 +56,13 @@ resource "github_repository_environment" "app" {
   environment = var.environment
 }
 
+resource "github_actions_environment_secret" "acr_name" {
+  repository      = github_repository.app.name
+  environment     = github_repository_environment.app.environment
+  secret_name     = "ACR_NAME"
+  plaintext_value = data.azurerm_container_registry.serve.name
+}
+
 resource "github_actions_environment_secret" "acr_token_username" {
   repository      = github_repository.app.name
   environment     = github_repository_environment.app.environment

--- a/apps/app/repository.tf
+++ b/apps/app/repository.tf
@@ -29,14 +29,12 @@ resource "github_team" "owners" {
 }
 
 resource "github_team_members" "owners" {
-  team_id = github_team.owners.id
+  for_each = var.app_config.owners
+  team_id  = github_team.owners.id
 
-  dynamic "members" {
-    for_each = var.app_config.owners
-    content {
-      username = members.value.gh_username
-      role     = "member"
-    }
+  members {
+    username = each.value
+    role     = "maintainer"
   }
 }
 
@@ -53,7 +51,7 @@ resource "github_repository_file" "codeowners" {
   content             = <<EOF
 # Owners for branch protection
 # Users within this team are required reviewers for this deployment branch
-*       @${github_owner}/${github_team.owners.slug}
+*       @${var.github_owner}/${github_team.owners.slug}
 EOF
   commit_message      = "Add codeowners (managed by Terraform)"
   commit_author       = "Terraform"
@@ -67,21 +65,19 @@ resource "github_team" "contributors" {
 }
 
 resource "github_team_members" "contributors" {
-  team_id = github_team.contributors.id
+  for_each = var.app_config.contributors
+  team_id  = github_team.contributors.id
 
-  dynamic "members" {
-    for_each = var.app_config.contributors
-    content {
-      username = members.value.gh_username
-      role     = "member"
-    }
+  members {
+    username = each.value
+    role     = "member"
   }
 }
 
 resource "github_team_repository" "contributors_repo_permissions" {
   team_id    = github_team.contributors.id
   repository = github_repository.app.name
-  permission = "pull"
+  permission = "push"
 }
 
 resource "github_branch" "deployment" {

--- a/apps/app/repository.tf
+++ b/apps/app/repository.tf
@@ -17,10 +17,10 @@ resource "github_repository" "app" {
   description = var.app_config.description
   visibility  = "public" # TODO: change to private after testing
 
-  # template {
-  #   owner      = "UCLH-Foundry"
-  #   repository = var.app_config.managed_repo.template
-  # }
+  template {
+    owner      = "UCLH-Foundry"
+    repository = var.app_config.managed_repo.template
+  }
 }
 
 resource "github_team" "contributors" {

--- a/apps/app/repository.tf
+++ b/apps/app/repository.tf
@@ -15,8 +15,7 @@
 resource "github_repository" "app" {
   name        = var.app_id
   description = var.app_config.description
-  visibility  = "public" # TODO: change to private after testing
-
+  visibility  = var.app_config.managed_repo.private ? "private" : "public"
   template {
     owner      = "UCLH-Foundry"
     repository = var.app_config.managed_repo.template

--- a/apps/app/repository.tf
+++ b/apps/app/repository.tf
@@ -22,3 +22,9 @@ resource "github_repository" "example" {
     repository = "terraform-template-module"
   }
 }
+
+resource "github_actions_secret" "example_secret" {
+  repository      = "example_repository"
+  secret_name     = "ACR_REPOSITORY_TOKEN"
+  plaintext_value = var.some_secret_string
+}

--- a/apps/app/repository.tf
+++ b/apps/app/repository.tf
@@ -17,14 +17,48 @@ resource "github_repository" "app" {
   description = var.app_config.description
   visibility  = "private"
 
-  template {
-    owner      = "UCLH-Foundry"
-    repository = var.managed_repo.template
-  }
+  # template {
+  #   owner      = "UCLH-Foundry"
+  #   repository = var.app_config.managed_repo.template
+  # }
 }
 
-resource "github_actions_secret" "example_secret" {
-  repository      = "example_repository"
-  secret_name     = "ACR_REPOSITORY_TOKEN"
-  plaintext_value = var.some_secret_string
+resource "github_team" "contributors" {
+  name        = "${var.app_id} - contributors"
+  description = "Contributors to the ${var.app_id} FlowEHR app."
+}
+
+resource "azurerm_container_registry_scope_map" "app_access" {
+  name                    = "acr-scopes-${replace(var.app_id, "_", "")}"
+  container_registry_name = data.azurerm_container_registry.serve.name
+  resource_group_name     = var.resource_group_name
+
+  actions = [
+    "repositories/${var.app_id}/content/read",
+    "repositories/${var.app_id}/content/write"
+  ]
+}
+
+resource "azurerm_container_registry_token" "app_access" {
+  name                    = replace(replace(var.app_id, "_", ""), "-", "")
+  container_registry_name = data.azurerm_container_registry.serve.name
+  resource_group_name     = var.resource_group_name
+  scope_map_id            = azurerm_container_registry_scope_map.app_access.id
+}
+
+resource "azurerm_container_registry_token_password" "app_access" {
+  container_registry_token_id = azurerm_container_registry_token.app_access.id
+  password1 {}
+}
+
+resource "github_repository_environment" "app" {
+  repository  = github_repository.app.name
+  environment = var.environment
+}
+
+resource "github_actions_environment_secret" "acr_token" {
+  repository      = github_repository.app.name
+  environment     = github_repository_environment.app.environment
+  secret_name     = "ACR_TOKEN"
+  plaintext_value = azurerm_container_registry_token_password.app_access.password1[0].value
 }

--- a/apps/app/repository.tf
+++ b/apps/app/repository.tf
@@ -15,7 +15,7 @@
 resource "github_repository" "app" {
   name        = var.app_id
   description = var.app_config.description
-  visibility  = "private"
+  visibility  = "public" # TODO: change to private after testing
 
   # template {
   #   owner      = "UCLH-Foundry"
@@ -56,9 +56,16 @@ resource "github_repository_environment" "app" {
   environment = var.environment
 }
 
-resource "github_actions_environment_secret" "acr_token" {
+resource "github_actions_environment_secret" "acr_token_username" {
   repository      = github_repository.app.name
   environment     = github_repository_environment.app.environment
-  secret_name     = "ACR_TOKEN"
+  secret_name     = "ACR_USERNAME"
+  plaintext_value = azurerm_container_registry_token.app_access.name
+}
+
+resource "github_actions_environment_secret" "acr_token_password" {
+  repository      = github_repository.app.name
+  environment     = github_repository_environment.app.environment
+  secret_name     = "ACR_PASSWORD"
   plaintext_value = azurerm_container_registry_token_password.app_access.password1[0].value
 }

--- a/apps/app/repository.tf
+++ b/apps/app/repository.tf
@@ -12,4 +12,13 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-// TODO: GH stuff will go here
+resource "github_repository" "example" {
+  name        = "example"
+  description = "My awesome codebase"
+  visibility  = "private"
+
+  template {
+    owner      = "github"
+    repository = "terraform-template-module"
+  }
+}

--- a/apps/app/repository.tf
+++ b/apps/app/repository.tf
@@ -12,14 +12,14 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-resource "github_repository" "example" {
-  name        = "example"
-  description = "My awesome codebase"
+resource "github_repository" "app" {
+  name        = var.app_id
+  description = var.app_config.description
   visibility  = "private"
 
   template {
-    owner      = "github"
-    repository = "terraform-template-module"
+    owner      = "UCLH-Foundry"
+    repository = var.managed_repo.template
   }
 }
 

--- a/apps/app/variables.tf
+++ b/apps/app/variables.tf
@@ -34,6 +34,10 @@ variable "naming_suffix" {
   type = string
 }
 
+variable "environment" {
+  type = string
+}
+
 variable "resource_group_name" {
   type = string
 }

--- a/apps/app/variables.tf
+++ b/apps/app/variables.tf
@@ -74,6 +74,10 @@ variable "feature_store_server_name" {
   type = string
 }
 
+variable "github_owner" {
+  type = string
+}
+
 variable "app_config" {
   type = object({
     name        = string

--- a/apps/app/variables.tf
+++ b/apps/app/variables.tf
@@ -78,7 +78,10 @@ variable "app_config" {
   type = object({
     name        = string
     description = string
-    owner       = string
+    owners = list(object({
+      email       = string
+      gh_username = string
+    }))
 
     contributors = list(object({
       email       = string
@@ -86,9 +89,10 @@ variable "app_config" {
     }))
 
     managed_repo = object({
-      private          = bool
-      template         = string,
-      branch_approvers = list(string)
+      private               = bool
+      template              = string,
+      num_of_approvals      = optional(number, 1),
+      dismiss_stale_reviews = optional(bool, false)
     })
 
     env = optional(map(string))

--- a/apps/app/variables.tf
+++ b/apps/app/variables.tf
@@ -86,6 +86,7 @@ variable "app_config" {
     }))
 
     managed_repo = object({
+      private          = bool
       template         = string,
       branch_approvers = list(string)
     })

--- a/apps/app/variables.tf
+++ b/apps/app/variables.tf
@@ -80,17 +80,10 @@ variable "github_owner" {
 
 variable "app_config" {
   type = object({
-    name        = string
-    description = string
-    owners = list(object({
-      email       = string
-      gh_username = string
-    }))
-
-    contributors = list(object({
-      email       = string
-      gh_username = string
-    }))
+    name         = string
+    description  = string
+    owners       = set(string)
+    contributors = set(string)
 
     managed_repo = object({
       private               = bool

--- a/apps/apps.sample.yaml
+++ b/apps/apps.sample.yaml
@@ -3,11 +3,9 @@ dash_seedling: # unique ID for the app
   name: Dash Seedling
   description: Hello world app for Dash
   owners: # owners to add to repo (for reviews)
-    - email: me@mycompany.com
-      gh_username: octocat
+    - octocat
   contributors: # contributors to add to repo
-    - email: contributor@mycompany.com
-      gh_username: octocat
+    - octokitten
   managed_repo: # details for created repo
     private: false # repo visibility
     template: Dash-Seedling

--- a/apps/apps.sample.yaml
+++ b/apps/apps.sample.yaml
@@ -7,6 +7,7 @@ dash_seedling: # unique ID for the app
     - email: contributor@mycompany.com
       gh_username: octocat
   managed_repo: # details for created repo
+    private: false # repo visibility
     template: Dash-Seedling
     branch_approvers:
       - important_persons_gh_username

--- a/apps/apps.sample.yaml
+++ b/apps/apps.sample.yaml
@@ -2,14 +2,16 @@
 dash_seedling: # unique ID for the app
   name: Dash Seedling
   description: Hello world app for Dash
-  owner: me@mycompany.com
+  owners: # owners to add to repo (for reviews)
+    - email: me@mycompany.com
+      gh_username: octocat
   contributors: # contributors to add to repo
     - email: contributor@mycompany.com
       gh_username: octocat
   managed_repo: # details for created repo
     private: false # repo visibility
     template: Dash-Seedling
-    branch_approvers:
-      - important_persons_gh_username
+    num_of_approvals: 1
+    dismiss_stale_reviews: false
   env: # any env vars to pass to the app container
     WEBSITES_PORT: 8000

--- a/apps/apps.sample.yaml
+++ b/apps/apps.sample.yaml
@@ -2,7 +2,7 @@
 dash_seedling: # unique ID for the app
   name: Dash Seedling
   description: Hello world app for Dash
-  owners: # owners to add to repo (for reviews)
+  owners: # GitHub usernames of owners to add to repo (for reviews)
     - octocat
   contributors: # contributors to add to repo
     - octokitten

--- a/apps/main.tf
+++ b/apps/main.tf
@@ -28,5 +28,6 @@ module "app" {
   cosmos_account_name       = var.serve_cosmos_account_name
   feature_store_db_name     = var.transform_feature_store_db_name
   feature_store_server_name = var.transform_feature_store_server_name
+  github_owner              = var.github_owner
   app_config                = each.value
 }

--- a/apps/main.tf
+++ b/apps/main.tf
@@ -17,6 +17,7 @@ module "app" {
   source                    = "./app"
   app_id                    = each.key
   naming_suffix             = var.naming_suffix
+  environment               = var.environment
   local_mode                = var.local_mode
   webapps_subnet_id         = var.serve_webapps_subnet_id
   resource_group_name       = var.core_rg_name

--- a/apps/terragrunt.hcl
+++ b/apps/terragrunt.hcl
@@ -68,5 +68,5 @@ inputs = {
   serve_cosmos_account_name   = dependency.serve.outputs.cosmos_account_name
   serve_webapps_subnet_id     = dependency.serve.outputs.webapps_subnet_id
 
-  github_owner = get_env(GITHUB_OWNER)
+  github_owner = get_env("GITHUB_OWNER")
 }

--- a/apps/terragrunt.hcl
+++ b/apps/terragrunt.hcl
@@ -38,9 +38,7 @@ generate "provider" {
   contents  = <<EOF
 ${include.root.locals.azure_provider}
 
-provider "github" {
-  owner = "${get_env("GITHUB_OWNER")}"
-}
+provider "github" {}
 EOF
 }
 
@@ -69,4 +67,6 @@ inputs = {
   serve_acr_name              = dependency.serve.outputs.acr_name
   serve_cosmos_account_name   = dependency.serve.outputs.cosmos_account_name
   serve_webapps_subnet_id     = dependency.serve.outputs.webapps_subnet_id
+
+  github_owner = get_env(GITHUB_OWNER)
 }

--- a/apps/terragrunt.hcl
+++ b/apps/terragrunt.hcl
@@ -68,5 +68,5 @@ inputs = {
   serve_cosmos_account_name   = dependency.serve.outputs.cosmos_account_name
   serve_webapps_subnet_id     = dependency.serve.outputs.webapps_subnet_id
 
-  github_owner = get_env("GITHUB_OWNER")
+  github_owner = get_env("GITHUB_OWNER", "")
 }

--- a/apps/terragrunt.hcl
+++ b/apps/terragrunt.hcl
@@ -39,8 +39,7 @@ generate "provider" {
 ${include.root.locals.azure_provider}
 
 provider "github" {
-  owner = ${get_env("GH_OWNER")}
-  token = ${get_env("GH_TOKEN")}
+  owner = "${get_env("GITHUB_OWNER")}"
 }
 EOF
 }

--- a/apps/terragrunt.hcl
+++ b/apps/terragrunt.hcl
@@ -16,6 +16,34 @@ include "root" {
   path = find_in_parent_folders()
 }
 
+generate "terraform" {
+  path      = "terraform.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+terraform {
+  required_version = "${include.root.locals.terraform_version}"
+
+  required_providers {
+    ${include.root.locals.required_provider_azure}
+    ${include.root.locals.required_provider_github}
+  }
+}
+EOF
+}
+
+generate "provider" {
+  path      = "provider.tf"
+  if_exists = "overwrite_terragrunt"
+  contents  = <<EOF
+${include.root.locals.azure_provider}
+
+provider "github" {
+  owner = ${get_env("GH_OWNER")}
+  token = ${get_env("GH_TOKEN")}
+}
+EOF
+}
+
 dependency "core" {
   config_path = "${get_repo_root()}/infrastructure/core"
 }

--- a/apps/terragrunt.hcl
+++ b/apps/terragrunt.hcl
@@ -13,7 +13,8 @@
 #  limitations under the License.
 
 include "root" {
-  path = find_in_parent_folders()
+  path   = find_in_parent_folders()
+  expose = true
 }
 
 generate "terraform" {

--- a/apps/variables.tf
+++ b/apps/variables.tf
@@ -22,6 +22,10 @@ variable "truncated_naming_suffix" {
   description = "Truncated (max 20 chars, no hyphens etc.) suffix for e.g storage accounts"
 }
 
+variable "environment" {
+  type = string
+}
+
 variable "tags" {
   type = map(any)
 }

--- a/apps/variables.tf
+++ b/apps/variables.tf
@@ -73,3 +73,7 @@ variable "serve_acr_name" {
 variable "serve_webapps_subnet_id" {
   type = string
 }
+
+variable "github_owner" {
+  type = string
+}

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -15,3 +15,7 @@ data_source_connections:
       dns_zones:
         - __CHANGE_ME__
     connection_string: postgresql://<hostname>:5432/<database-name>?user=<username>&password=<***>
+
+github:
+  gh_owner: __CHANGE_ME__
+  gh_token: __CHANGE_ME__

--- a/config_schema.json
+++ b/config_schema.json
@@ -18,7 +18,7 @@
         "environment": {
             "description": "Unique environment name for differentiating deployment environments",
             "type": "string",
-            "pattern": "^[a-zA-Z 0-9\\_-]*$"
+            "pattern": "^[a-zA-Z0-9\\_-]*$"
         },
         "arm_subscription_id": {
             "description": "Subscription Id for the Azure subscription to deploy to",

--- a/infrastructure/ci-auth/.terraform.lock.hcl
+++ b/infrastructure/ci-auth/.terraform.lock.hcl
@@ -1,0 +1,41 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "2.35.0"
+  constraints = "2.35.0"
+  hashes = [
+    "h1:yxuDZvYzlE8j+O57ZwRBTVnQQVKY31Ov266wTSvPxDA=",
+    "zh:186d97850249bdba95792592157191cbca0899001afc49aad966cd6bb428d035",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:60bc57c7aa4a906a90a1edd6093055c41db556a011a3eb64891864ddd623fcd7",
+    "zh:629593e4cca999e2010c2ccc8f190a811bfd6be36517ddac0693bf14c341620d",
+    "zh:75082d1c8b90674ade80ff22f87b26be7d440c8e3af533e5b320495943294d0b",
+    "zh:7595b794511fc501cd261135d435837a1598da955088627275ef0ee58cb24c0a",
+    "zh:82065078ee228774ecbf13da5eb7bf87c8477a7a2e4e4e99d68f52748e0e6db2",
+    "zh:87feeed8443a2d88707524754b0bd1a6af869e22756d3d450427771f2027b35f",
+    "zh:d464aa23bdbbe83d2482d1a10724cd947d8939e66723604874accd023799a4b2",
+    "zh:db063e448d11b5ccbbd56d0207fb1ce952f9ddbfbe8164d563496790aaa6b6c4",
+    "zh:ea360fbeaa28c49179184b2be0cfaea03fbd551b87db267c8783addba09362dc",
+    "zh:faaa1686abc4861b96925d2f8f54ea35ec00c973fb2523f362d057ab953a76ed",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version = "3.45.0"
+  hashes = [
+    "h1:WupjURkT1JPNBRzKmrSsD1Y8zhuQnL3ctKBpNLZBsLA=",
+    "zh:04c5dbb8845366ce5eb0dc2d55e151270cc2c0ace20993867fdae9af43b953ad",
+    "zh:2589585da615ccae341400d45d672ee3fae413fdd88449b5befeff12a85a44b2",
+    "zh:603869ed98fff5d9bf841a51afd9e06b628533c59356c8433aef4b15df63f5f7",
+    "zh:853fecab9c987b6772c8d9aa10362675f6c626b60ebc7118aa33ce91366fcc38",
+    "zh:979848c45e8e058862c36ba3a661457f7c81ef26ebb6634f479600de9c203d65",
+    "zh:9b512c8588ecc9c1b803b746a3a8517422561a918f0dfb0faaa707ed53ef1760",
+    "zh:a9601ffb58043426bcff1220662d6d137f0b2857a24f2dcf180aeac2c9cea688",
+    "zh:d52d2652328f0ed3ba202561d88cb9f43c174edbfaab1abf69f772125dbfe15e",
+    "zh:d92d91ca597c47f575bf3ae129f4b723be9b7dcb71b906ec6ec740fac29b1aaa",
+    "zh:ded73b730e4197b70fda9e83447c119f92f75dc37be3ff2ed45730c8f0348c28",
+    "zh:ec37ac332d50f8ca5827f97198346b0f8ecbf470e2e3ba1e027bb389d826b902",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infrastructure/core/.terraform.lock.hcl
+++ b/infrastructure/core/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.45.0"
+  constraints = ">= 3.32.0"
+  hashes = [
+    "h1:WupjURkT1JPNBRzKmrSsD1Y8zhuQnL3ctKBpNLZBsLA=",
+    "zh:04c5dbb8845366ce5eb0dc2d55e151270cc2c0ace20993867fdae9af43b953ad",
+    "zh:2589585da615ccae341400d45d672ee3fae413fdd88449b5befeff12a85a44b2",
+    "zh:603869ed98fff5d9bf841a51afd9e06b628533c59356c8433aef4b15df63f5f7",
+    "zh:853fecab9c987b6772c8d9aa10362675f6c626b60ebc7118aa33ce91366fcc38",
+    "zh:979848c45e8e058862c36ba3a661457f7c81ef26ebb6634f479600de9c203d65",
+    "zh:9b512c8588ecc9c1b803b746a3a8517422561a918f0dfb0faaa707ed53ef1760",
+    "zh:a9601ffb58043426bcff1220662d6d137f0b2857a24f2dcf180aeac2c9cea688",
+    "zh:d52d2652328f0ed3ba202561d88cb9f43c174edbfaab1abf69f772125dbfe15e",
+    "zh:d92d91ca597c47f575bf3ae129f4b723be9b7dcb71b906ec6ec740fac29b1aaa",
+    "zh:ded73b730e4197b70fda9e83447c119f92f75dc37be3ff2ed45730c8f0348c28",
+    "zh:ec37ac332d50f8ca5827f97198346b0f8ecbf470e2e3ba1e027bb389d826b902",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infrastructure/serve/.terraform.lock.hcl
+++ b/infrastructure/serve/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.45.0"
+  constraints = ">= 3.32.0"
+  hashes = [
+    "h1:WupjURkT1JPNBRzKmrSsD1Y8zhuQnL3ctKBpNLZBsLA=",
+    "zh:04c5dbb8845366ce5eb0dc2d55e151270cc2c0ace20993867fdae9af43b953ad",
+    "zh:2589585da615ccae341400d45d672ee3fae413fdd88449b5befeff12a85a44b2",
+    "zh:603869ed98fff5d9bf841a51afd9e06b628533c59356c8433aef4b15df63f5f7",
+    "zh:853fecab9c987b6772c8d9aa10362675f6c626b60ebc7118aa33ce91366fcc38",
+    "zh:979848c45e8e058862c36ba3a661457f7c81ef26ebb6634f479600de9c203d65",
+    "zh:9b512c8588ecc9c1b803b746a3a8517422561a918f0dfb0faaa707ed53ef1760",
+    "zh:a9601ffb58043426bcff1220662d6d137f0b2857a24f2dcf180aeac2c9cea688",
+    "zh:d52d2652328f0ed3ba202561d88cb9f43c174edbfaab1abf69f772125dbfe15e",
+    "zh:d92d91ca597c47f575bf3ae129f4b723be9b7dcb71b906ec6ec740fac29b1aaa",
+    "zh:ded73b730e4197b70fda9e83447c119f92f75dc37be3ff2ed45730c8f0348c28",
+    "zh:ec37ac332d50f8ca5827f97198346b0f8ecbf470e2e3ba1e027bb389d826b902",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infrastructure/transform/.terraform.lock.hcl
+++ b/infrastructure/transform/.terraform.lock.hcl
@@ -1,0 +1,100 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/databricks/databricks" {
+  version     = "1.9.1"
+  constraints = "1.9.1"
+  hashes = [
+    "h1:A5oD/Qf6MQYDLoMjoJ86+mHo073OOMGA5gcQYLBwP9I=",
+    "zh:0abe153b02493780fc7bb6d6d6c817b4c1144b8850ceec4eb182ce7956521461",
+    "zh:37e374515f36486b5729fd43ba094816c448d405f7673da53857b28947987571",
+    "zh:441847508571125c9db8a30da32fa2344dbf6c00563fcd819a3e813e626c4b64",
+    "zh:5054b850575b5f79c1cdf5d616c290052f3bdb13029c034c6417bc05a3129d50",
+    "zh:52eab57817ee97ea5fd9e204f2dfaddcd19371e3353e9f96accd29f49811c3d1",
+    "zh:78c32ebcd6da7c6504574d636b1dc63b8a4954b3584989d64422ec8a704c3537",
+    "zh:a6bdb4ab8dae9a737d6b69b9aac706da2aadda159d021aee1bf1836774e0cce5",
+    "zh:dc416e45b6b6157192cde6a776bf4b98e88c5bf266216ab788ab0f51f1a90641",
+    "zh:e69c0c5e110a4b74804061d7e2a348e192a688faec67d4f2d60a600223313e9c",
+    "zh:fa4bdb0fd51d3710282ac04dc1b30ea813b446c1bbd7b901622612f47526906b",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azuread" {
+  version     = "2.35.0"
+  constraints = "2.35.0"
+  hashes = [
+    "h1:yxuDZvYzlE8j+O57ZwRBTVnQQVKY31Ov266wTSvPxDA=",
+    "zh:186d97850249bdba95792592157191cbca0899001afc49aad966cd6bb428d035",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:60bc57c7aa4a906a90a1edd6093055c41db556a011a3eb64891864ddd623fcd7",
+    "zh:629593e4cca999e2010c2ccc8f190a811bfd6be36517ddac0693bf14c341620d",
+    "zh:75082d1c8b90674ade80ff22f87b26be7d440c8e3af533e5b320495943294d0b",
+    "zh:7595b794511fc501cd261135d435837a1598da955088627275ef0ee58cb24c0a",
+    "zh:82065078ee228774ecbf13da5eb7bf87c8477a7a2e4e4e99d68f52748e0e6db2",
+    "zh:87feeed8443a2d88707524754b0bd1a6af869e22756d3d450427771f2027b35f",
+    "zh:d464aa23bdbbe83d2482d1a10724cd947d8939e66723604874accd023799a4b2",
+    "zh:db063e448d11b5ccbbd56d0207fb1ce952f9ddbfbe8164d563496790aaa6b6c4",
+    "zh:ea360fbeaa28c49179184b2be0cfaea03fbd551b87db267c8783addba09362dc",
+    "zh:faaa1686abc4861b96925d2f8f54ea35ec00c973fb2523f362d057ab953a76ed",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "3.45.0"
+  constraints = ">= 3.32.0"
+  hashes = [
+    "h1:WupjURkT1JPNBRzKmrSsD1Y8zhuQnL3ctKBpNLZBsLA=",
+    "zh:04c5dbb8845366ce5eb0dc2d55e151270cc2c0ace20993867fdae9af43b953ad",
+    "zh:2589585da615ccae341400d45d672ee3fae413fdd88449b5befeff12a85a44b2",
+    "zh:603869ed98fff5d9bf841a51afd9e06b628533c59356c8433aef4b15df63f5f7",
+    "zh:853fecab9c987b6772c8d9aa10362675f6c626b60ebc7118aa33ce91366fcc38",
+    "zh:979848c45e8e058862c36ba3a661457f7c81ef26ebb6634f479600de9c203d65",
+    "zh:9b512c8588ecc9c1b803b746a3a8517422561a918f0dfb0faaa707ed53ef1760",
+    "zh:a9601ffb58043426bcff1220662d6d137f0b2857a24f2dcf180aeac2c9cea688",
+    "zh:d52d2652328f0ed3ba202561d88cb9f43c174edbfaab1abf69f772125dbfe15e",
+    "zh:d92d91ca597c47f575bf3ae129f4b723be9b7dcb71b906ec6ec740fac29b1aaa",
+    "zh:ded73b730e4197b70fda9e83447c119f92f75dc37be3ff2ed45730c8f0348c28",
+    "zh:ec37ac332d50f8ca5827f97198346b0f8ecbf470e2e3ba1e027bb389d826b902",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.2.1"
+  constraints = "3.2.1"
+  hashes = [
+    "h1:wqgRvlyVIbkCeCQs+5jj6zVuQL0KDxZZtNofGqqlSdI=",
+    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
+    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
+    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
+    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
+    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
+    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
+    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
+    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
+    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
+    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.4.3"
+  constraints = "3.4.3"
+  hashes = [
+    "h1:hV66lcagXXRwwCW3Y542bI1JgPo8z/taYKT7K+a2Z5U=",
+    "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
+    "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
+    "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:84103eae7251384c0d995f5a257c72b0096605048f757b749b7b62107a5dccb3",
+    "zh:8ee974b110adb78c7cd18aae82b2729e5124d8f115d484215fd5199451053de5",
+    "zh:9dd4561e3c847e45de603f17fa0c01ae14cae8c4b7b4e6423c9ef3904b308dda",
+    "zh:bb07bb3c2c0296beba0beec629ebc6474c70732387477a65966483b5efabdbc6",
+    "zh:e891339e96c9e5a888727b45b2e1bb3fcbdfe0fd7c5b4396e4695459b38c8cb1",
+    "zh:ea4739860c24dfeaac6c100b2a2e357106a89d18751f7693f3c31ecf6a996f8d",
+    "zh:f0c76ac303fd0ab59146c39bc121c5d7d86f878e9a69294e29444d4c653786f8",
+    "zh:f143a9a5af42b38fed328a161279906759ff39ac428ebcfe55606e05e1518b93",
+  ]
+}

--- a/scripts/load_env.sh
+++ b/scripts/load_env.sh
@@ -53,6 +53,7 @@ export_config_from_yaml () {
     # Export as UPPERCASE keys env vars
     # shellcheck disable=SC2046
     export $(yq e "$GET_LEAF_KEYS|$UPCASE_KEYS| $FORMAT_FOR_ENV_EXPORT" "$config_file_path")
+
     # Export as Terraform keys env vars
     # shellcheck disable=SC2046
     export $(yq e "$GET_LEAF_KEYS|$TF_KEYS| $FORMAT_FOR_ENV_EXPORT" "$config_file_path")

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -125,6 +125,7 @@ inputs = {
   location = get_env("LOCATION")
   naming_suffix = get_env("NAMING_SUFFIX")
   truncated_naming_suffix = get_env("TRUNCATED_NAMING_SUFFIX")
+  environment = get_env("ENVIRONMENT")
   deployer_ip_address = get_env("DEPLOYER_IP_ADDRESS", "") // deployer's IP address is added to resource firewall exceptions IF in local_mode
   local_mode = get_env("LOCAL_MODE", false)
   core_address_space = get_env("CORE_ADDRESS_SPACE")

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -42,6 +42,7 @@ provider "azurerm" {
   }
 }
 EOF
+
   required_provider_azure = <<EOF
 azurerm = {
   source  = "hashicorp/azurerm"

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -76,6 +76,13 @@ EOF
       version = "3.2.1"
     }
 EOF
+
+  required_provider_github = <<EOF
+  github = {
+      source  = "integrations/github"
+      version = "~> 5.0"
+    }
+EOF
 }
 
 generate "terraform" {


### PR DESCRIPTION
Resolves #73 
Resolves #74 
Resolves #72 

This PR creates all the required resources for an app being hosted within a managed GitHub repo on `make apps`

Consists of:
- [x] new repository with app name and description
- [x] new GitHub team with all users defined in `contributors` block
- [x] Link new GH team as contributors to the new repo
- [x] create a deployment branch with the environment name from core config
- [x] add branch protection policy on this branch as per the `branch_approvers` config
- [x] create GH environment with same name as FlowEHR environment
- [x] Create repository scoped token in `platform.tf` and use in `repository.tf` (https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/container_registry_token)
- [x] Add ACR repository token secret as environment secret
- [x] Link the gh environment to only be deployable to using deployment branch