### PR TITLE
Skip pulling repo if already there

### DIFF
--- a/scripts/pipeline_repo_checkout.sh
+++ b/scripts/pipeline_repo_checkout.sh
@@ -38,8 +38,7 @@ while IFS=$'\n' read -r repo _; do
   # If the directory with checked out repo already exists, pull the latest
   dir_name=$(basename "${repo}" | sed -e 's/\.git$//')
   if [ -d "${dir_name}" ]; then
-    # This will fail if there are local changes present
-    eval "${GIT_COMMAND} pull ${repo}"
+    echo "Repo already exists, skipping"
   else
     eval "${GIT_COMMAND} clone ${repo}"
   fi


### PR DESCRIPTION
In https://github.com/UCLH-Foundry/FlowEHR/pull/127  we changed the logic for pulling pipeline repos to run `git pull` on an existing checked out repo, but it looks like it doesn't work in certain git configurations. 

Skipping this step altogether and just leaving code there if it already exists to support local iteration 