### PR TITLE
Add datafactory as an extension to the devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,7 +43,8 @@
 			"terragrunt": "0.42.8"
 		},
 		"ghcr.io/devcontainers/features/azure-cli:1": {
-			"version": "2.44.1"
+			"version": "2.44.1",
+			"extensions": "datafactory"
 		},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {},


### PR DESCRIPTION
Add datafactory as an extension to the devcontainer.

As I understand it (?), the devcontainer is being built from the main branch now, so this needs to go in before the PR where it is actually needed: https://github.com/UCLH-Foundry/FlowEHR/pull/156 