### PR TITLE
Move devcontainer name to global env

### DIFF
--- a/.github/workflows/devcontainer_make_command.yml
+++ b/.github/workflows/devcontainer_make_command.yml
@@ -45,12 +45,13 @@ on:
       ORG_GITHUB_TOKEN:
         required: true
 
+env:
+  DEVCONTAINER_NAME: flowehr/devcontainer
+
 jobs:
   make_core:
     runs-on: ubuntu-latest
     environment: ${{ inputs.environment }}
-    env:
-      DEVCONTAINER_NAME: flowehr/devcontainer
     outputs:
       dc_tag: ${{ steps.dc.outputs.tag }}
       dc_runner_name: ${{ steps.dc.outputs.runner_name }}


### PR DESCRIPTION
Currently destroy step in PRs is unable to access the devcontainer name as it's in a different job's scope. This moves it to a global env so all jobs can access. Tested in my fork