### PR TITLE
Add group.readwrite.all to ci

### DIFF
--- a/bootstrap/ci/main.tf
+++ b/bootstrap/ci/main.tf
@@ -47,6 +47,11 @@ resource "azuread_application" "ci_app" {
       id   = azuread_service_principal.msgraph.app_role_ids["AppRoleAssignment.ReadWrite.All"]
       type = "Role"
     }
+
+    resource_access {
+      id   = azuread_service_principal.msgraph.app_role_ids["Group.ReadWrite.All"]
+      type = "Role"
+    }
   }
 }
 
@@ -68,6 +73,12 @@ resource "azuread_app_role_assignment" "app_readwrite_all" {
 
 resource "azuread_app_role_assignment" "approleassignment_readwrite_all" {
   app_role_id         = azuread_service_principal.msgraph.app_role_ids["AppRoleAssignment.ReadWrite.All"]
+  principal_object_id = azuread_service_principal.ci_app.id
+  resource_object_id  = azuread_service_principal.msgraph.object_id
+}
+
+resource "azuread_app_role_assignment" "group_readwrite_all" {
+  app_role_id         = azuread_service_principal.msgraph.app_role_ids["Group.ReadWrite.All"]
   principal_object_id = azuread_service_principal.ci_app.id
   resource_object_id  = azuread_service_principal.msgraph.object_id
 }


### PR DESCRIPTION
To create the AD Groups for the feature store etc., the ci apps need `group.readwrite.all` permissions