### PR TITLE
Add concurrency blocks to infra-test CI workflows

### DIFF
--- a/.github/workflows/deploy_infra_test.yml
+++ b/.github/workflows/deploy_infra_test.yml
@@ -22,6 +22,10 @@ on:
 permissions:
   pull-requests: read
 
+# Only have a single instance of this workflow running at any time
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   deploy:
     uses: ./.github/workflows/devcontainer_make_command.yml

--- a/.github/workflows/destroy_infra_test.yml
+++ b/.github/workflows/destroy_infra_test.yml
@@ -17,6 +17,10 @@ name: Destroy Infra-Test
 on:
   workflow_dispatch:
 
+# Only have a single instance of this workflow running at any time
+concurrency:
+  group: ${{ github.workflow }}
+
 jobs:
   destroy:
     uses: ./.github/workflows/devcontainer_make_command.yml


### PR DESCRIPTION
## Resolves #166 

See: https://docs.github.com/en/actions/using-jobs/using-concurrency