### PR TITLE
Add gh cert in optional dev container env args

### DIFF
--- a/.github/workflows/devcontainer_make_command.yml
+++ b/.github/workflows/devcontainer_make_command.yml
@@ -10,7 +10,7 @@
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
-# limitations under the License.
+#  limitations under the License.
 ---
 name: Make command
 
@@ -45,7 +45,7 @@ on:
       FLOWEHR_GITHUB_TOKEN:
         required: true
       GH_APP_CERT:
-        required: true
+        required: false
 
 env:
   DEVCONTAINER_NAME: flowehr/devcontainer
@@ -89,7 +89,6 @@ jobs:
           echo "Running [${setup_command}] setup"
           echo "Running [${build_agent_command}] on the build agent"
           echo "Running [${post_build_agent_command}] teardown"
-
           echo "setup_command=${setup_command}" >> $GITHUB_OUTPUT
           echo "build_agent_command=${build_agent_command}" >> $GITHUB_OUTPUT
           echo "post_build_agent_command=${post_build_agent_command}" >> $GITHUB_OUTPUT
@@ -132,9 +131,10 @@ jobs:
       - name: Deploy core and build agent
         uses: devcontainers/ci@v0.3
         env:
-          # Add suffix as step env so it's only passed as an env var if it's not empty
+          # Add optionals as step envs so only passed as env vars if not empty
           # https://github.com/devcontainers/ci/issues/231
           SUFFIX_OVERRIDE: ${{ inputs.suffix_override }}
+          GH_APP_CERT: ${{ secrets.GH_APP_CERT }}
         with:
           imageName: ${{ steps.dc.outputs.image_path }}
           imageTag: ${{ steps.dc.outputs.tag }}
@@ -154,7 +154,7 @@ jobs:
             CI_RESOURCE_GROUP=${{ vars.CI_RESOURCE_GROUP }}
             CI_STORAGE_ACCOUNT=${{ vars.CI_STORAGE_ACCOUNT }}
             FLOWEHR_GITHUB_TOKEN=${{ secrets.FLOWEHR_GITHUB_TOKEN }}
-            GH_APP_CERT=${{ secrets.GH_APP_CERT }}
+            GH_APP_CERT
             TF_VAR_devcontainer_image=${{ env.DEVCONTAINER_NAME }}
             TF_VAR_devcontainer_tag=${{ steps.dc.outputs.tag }}
             TF_VAR_use_random_address_space=${{ (inputs.suffix_override != '' && '1') || '0' }}
@@ -235,6 +235,7 @@ jobs:
         uses: devcontainers/ci@v0.3
         env:
           SUFFIX_OVERRIDE: ${{ inputs.suffix_override }}
+          GH_APP_CERT: ${{ secrets.GH_APP_CERT }}
         with:
           # The image name cannot be set from the make_core output because it contains a secret
           imageName: ${{ vars.CI_CONTAINER_REGISTRY }}.azurecr.io/${{ env.DEVCONTAINER_NAME }}
@@ -255,7 +256,7 @@ jobs:
             CI_RESOURCE_GROUP=${{ vars.CI_RESOURCE_GROUP }}
             CI_STORAGE_ACCOUNT=${{ vars.CI_STORAGE_ACCOUNT }}
             FLOWEHR_GITHUB_TOKEN=${{ secrets.FLOWEHR_GITHUB_TOKEN }}
-            GH_APP_CERT=${{ secrets.GH_APP_CERT }}
+            GH_APP_CERT
             TF_VAR_use_random_address_space=${{ (inputs.suffix_override != '' && '1') || '0' }}
 
       - name: Clean up

--- a/apps/terragrunt.hcl
+++ b/apps/terragrunt.hcl
@@ -23,7 +23,7 @@ locals {
 
   # Get GitHub App PEM cert as string - first try local file otherwise look for env var
   github_app_cert_path = "${get_terragrunt_dir()}/github.pem"
-  github_app_cert      = fileexists(local.github_app_cert_path) ? file(local.github_app_cert_path) : get_env("GH_APP_CERT", null)
+  github_app_cert      = fileexists(local.github_app_cert_path) ? file(local.github_app_cert_path) : get_env("GH_APP_CERT", "")
 
   # Get app configuration from apps.yaml and app.{ENVIRONMENT}.yaml
   apps_config_path     = "${get_terragrunt_dir()}/apps.yaml"


### PR DESCRIPTION
Adds a fix for the devcontainer make commands treating the pem cert as multiple env vars

Also makes app cert optional in line with potential customers only deploying transform / serve without apps
