### PR TITLE
Add mock outputs for destroy to all layers

### DIFF
--- a/infrastructure/serve/terragrunt.hcl
+++ b/infrastructure/serve/terragrunt.hcl
@@ -18,6 +18,16 @@ include "root" {
 
 dependency "core" {
   config_path = "../core"
+
+  mock_outputs = {
+    core_rg_name                = "core_rg_name"
+    core_rg_location            = "core_rg_location"
+    core_kv_id                  = "core_kv_id"
+    core_vnet_name              = "core_vnet_name"
+    core_subnet_id              = "core_subnet_id"
+    serve_webapps_address_space = "serve_webapps_address_space"
+  }
+  mock_outputs_allowed_terraform_commands = ["destroy"]
 }
 
 inputs = {

--- a/infrastructure/transform/terragrunt.hcl
+++ b/infrastructure/transform/terragrunt.hcl
@@ -22,6 +22,18 @@ locals {
 
 dependency "core" {
   config_path = "../core"
+
+  mock_outputs = {
+    core_rg_name                       = "core_rg_name"
+    core_rg_location                   = "core_rg_location"
+    core_vnet_name                     = "core_vnet_name"
+    core_subnet_id                     = "core_subnet_id"
+    core_kv_id                         = "core_kv_id"
+    core_kv_uri                        = "core_kv_uri"
+    databricks_host_address_space      = "databricks_host_address_space"
+    databricks_container_address_space = "databricks_container_address_space"
+  }
+  mock_outputs_allowed_terraform_commands = ["destroy"]
 }
 
 generate "terraform" {

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -14,6 +14,13 @@
 
 dependency "bootstrap" {
   config_path = "${get_repo_root()}/bootstrap/local"
+
+  mock_outputs = {
+    naming_suffix           = "naming_suffix"
+    naming_suffix_truncated = "naming_suffix_truncated"
+    deployer_ip_address     = "deployer_ip_address"
+  }
+  mock_outputs_allowed_terraform_commands = ["destroy"]
 }
 
 locals {


### PR DESCRIPTION
## Resolves #186 

Adds mock outputs for all terragrunt layers to, hopefully fix destroys failing when layers have not been applied