### PR TITLE
Add App Auth

### DIFF
--- a/apps/.terraform.lock.hcl
+++ b/apps/.terraform.lock.hcl
@@ -60,6 +60,25 @@ provider "registry.terraform.io/hashicorp/external" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.4.3"
+  hashes = [
+    "h1:hV66lcagXXRwwCW3Y542bI1JgPo8z/taYKT7K+a2Z5U=",
+    "zh:41c53ba47085d8261590990f8633c8906696fa0a3c4b384ff6a7ecbf84339752",
+    "zh:59d98081c4475f2ad77d881c4412c5129c56214892f490adf11c7e7a5a47de9b",
+    "zh:686ad1ee40b812b9e016317e7f34c0d63ef837e084dea4a1f578f64a6314ad53",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:84103eae7251384c0d995f5a257c72b0096605048f757b749b7b62107a5dccb3",
+    "zh:8ee974b110adb78c7cd18aae82b2729e5124d8f115d484215fd5199451053de5",
+    "zh:9dd4561e3c847e45de603f17fa0c01ae14cae8c4b7b4e6423c9ef3904b308dda",
+    "zh:bb07bb3c2c0296beba0beec629ebc6474c70732387477a65966483b5efabdbc6",
+    "zh:e891339e96c9e5a888727b45b2e1bb3fcbdfe0fd7c5b4396e4695459b38c8cb1",
+    "zh:ea4739860c24dfeaac6c100b2a2e357106a89d18751f7693f3c31ecf6a996f8d",
+    "zh:f0c76ac303fd0ab59146c39bc121c5d7d86f878e9a69294e29444d4c653786f8",
+    "zh:f143a9a5af42b38fed328a161279906759ff39ac428ebcfe55606e05e1518b93",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/template" {
   version = "2.2.0"
   hashes = [

--- a/apps/app/acr.tf
+++ b/apps/app/acr.tf
@@ -1,0 +1,68 @@
+#  Copyright (c) University College London Hospitals NHS Foundation Trust
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+resource "azurerm_role_assignment" "webapp_acr" {
+  role_definition_name = "AcrPull"
+  scope                = data.azurerm_container_registry.serve.id
+  principal_id         = azurerm_linux_web_app.app.identity[0].principal_id
+}
+
+resource "azurerm_role_assignment" "webapp_testing_slot_acr" {
+  count                = var.app_config.add_testing_slot ? 1 : 0
+  role_definition_name = "AcrPull"
+  scope                = data.azurerm_container_registry.serve.id
+  principal_id         = azurerm_linux_web_app_slot.testing[0].identity[0].principal_id
+}
+
+# Create a web hook that triggers automated deployment of the Docker image
+resource "azurerm_container_registry_webhook" "webhook" {
+  count               = var.app_config.add_testing_slot ? 0 : 1
+  name                = "acrwh${replace(replace(var.app_id, "_", ""), "-", "")}"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  registry_name       = data.azurerm_container_registry.serve.name
+
+  service_uri = "https://${local.site_credential_name}:${local.site_credential_password}@${lower(azurerm_linux_web_app.app.name)}.scm.azurewebsites.net/api/registry/webhook"
+  status      = "enabled"
+  scope       = "${local.acr_repository}:latest"
+  actions     = ["push"]
+
+  custom_headers = {
+    "Content-Type" = "application/json"
+  }
+}
+
+# Create ACR repository token for app to use in cicd to push images
+resource "azurerm_container_registry_scope_map" "app_access" {
+  name                    = "acr-scopes-${replace(var.app_id, "_", "")}"
+  container_registry_name = data.azurerm_container_registry.serve.name
+  resource_group_name     = var.resource_group_name
+
+  actions = [
+    "repositories/${var.app_id}/content/read",
+    "repositories/${var.app_id}/content/write"
+  ]
+}
+
+resource "azurerm_container_registry_token" "app_access" {
+  name                    = replace(replace(var.app_id, "_", ""), "-", "")
+  container_registry_name = data.azurerm_container_registry.serve.name
+  resource_group_name     = var.resource_group_name
+  scope_map_id            = azurerm_container_registry_scope_map.app_access.id
+}
+
+resource "azurerm_container_registry_token_password" "app_access" {
+  container_registry_token_id = azurerm_container_registry_token.app_access.id
+  password1 {}
+}

--- a/apps/app/auth.tf
+++ b/apps/app/auth.tf
@@ -57,14 +57,3 @@ resource "azuread_application" "webapp_auth" {
     }
   }
 }
-
-resource "azuread_service_principal" "webapp_auth" {
-  for_each       = local.auth_webapp_names
-  application_id = azuread_application.webapp_auth[each.value].application_id
-  use_existing   = true
-}
-
-resource "azuread_application_password" "webapp_auth" {
-  for_each              = local.auth_webapp_names
-  application_object_id = azuread_application.webapp_auth[each.value].object_id
-}

--- a/apps/app/auth.tf
+++ b/apps/app/auth.tf
@@ -21,7 +21,7 @@ resource "random_uuid" "webapp_oauth2_id" {}
 
 resource "azuread_application" "webapp_auth" {
   for_each        = local.auth_webapp_names
-  display_name    = "flowehr-app-${each.value}"
+  display_name    = "flowehr-${each.value}"
   owners          = [data.azurerm_client_config.current.object_id]
   identifier_uris = ["api://${each.value}"]
 
@@ -29,7 +29,7 @@ resource "azuread_application" "webapp_auth" {
     resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
 
     resource_access {
-      id   = azuread_service_principal.msgraph.app_role_ids["User.Read.All"]
+      id   = azuread_service_principal.msgraph.oauth2_permission_scope_ids["User.Read"]
       type = "Scope"
     }
   }

--- a/apps/app/auth.tf
+++ b/apps/app/auth.tf
@@ -20,7 +20,7 @@ resource "azuread_service_principal" "msgraph" {
 resource "random_uuid" "webapp_oauth2_id" {}
 
 resource "azuread_application" "webapp_auth" {
-  for_each        = local.webapp_names
+  for_each        = local.auth_webapp_names
   display_name    = "flowehr-app-${each.value}"
   owners          = [data.azurerm_client_config.current.object_id]
   identifier_uris = ["api://${each.value}"]
@@ -29,7 +29,7 @@ resource "azuread_application" "webapp_auth" {
     resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
 
     resource_access {
-      id   = azuread_service_principal.msgraph.app_role_ids["User.Read"]
+      id   = azuread_service_principal.msgraph.app_role_ids["User.Read.All"]
       type = "Scope"
     }
   }
@@ -56,4 +56,15 @@ resource "azuread_application" "webapp_auth" {
       id_token_issuance_enabled     = true
     }
   }
+}
+
+resource "azuread_service_principal" "webapp_auth" {
+  for_each       = local.auth_webapp_names
+  application_id = azuread_application.webapp_auth[each.value].application_id
+  use_existing   = true
+}
+
+resource "azuread_application_password" "webapp_auth" {
+  for_each              = local.auth_webapp_names
+  application_object_id = azuread_application.webapp_auth[each.value].object_id
 }

--- a/apps/app/auth.tf
+++ b/apps/app/auth.tf
@@ -1,0 +1,59 @@
+#  Copyright (c) University College London Hospitals NHS Foundation Trust
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+resource "azuread_service_principal" "msgraph" {
+  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing   = true
+}
+
+resource "random_uuid" "webapp_oauth2_id" {}
+
+resource "azuread_application" "webapp_auth" {
+  for_each        = local.webapp_names
+  display_name    = "flowehr-app-${each.value}"
+  owners          = [data.azurerm_client_config.current.object_id]
+  identifier_uris = ["api://${each.value}"]
+
+  required_resource_access {
+    resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+
+    resource_access {
+      id   = azuread_service_principal.msgraph.app_role_ids["User.Read"]
+      type = "Scope"
+    }
+  }
+
+  api {
+    oauth2_permission_scope {
+      admin_consent_description  = "Allow the application to access ${each.value} on behalf of the signed-in user."
+      admin_consent_display_name = "Access ${each.value}"
+      enabled                    = true
+      id                         = random_uuid.webapp_oauth2_id.result
+      type                       = "User"
+      user_consent_description   = "Allow the application to access ${each.value} on your behalf."
+      user_consent_display_name  = "Access ${each.value}"
+      value                      = "user_impersonation"
+    }
+  }
+
+  web {
+    homepage_url  = "https://${each.value}.azurewebsites.net"
+    redirect_uris = ["https://${each.value}.azurewebsites.net/.auth/login/aad/callback"]
+
+    implicit_grant {
+      access_token_issuance_enabled = true
+      id_token_issuance_enabled     = true
+    }
+  }
+}

--- a/apps/app/cosmos.tf
+++ b/apps/app/cosmos.tf
@@ -1,0 +1,38 @@
+#  Copyright (c) University College London Hospitals NHS Foundation Trust
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+resource "azurerm_cosmosdb_sql_database" "app" {
+  name                = "${var.app_id}-state"
+  resource_group_name = var.resource_group_name
+  account_name        = var.cosmos_account_name
+}
+
+resource "azurerm_cosmosdb_sql_role_definition" "webapp" {
+  name                = "${var.app_id}-AccessCosmosSingleDB"
+  resource_group_name = var.resource_group_name
+  account_name        = var.cosmos_account_name
+  assignable_scopes   = ["${data.azurerm_cosmosdb_account.state_store.id}/dbs/${azurerm_cosmosdb_sql_database.app.name}"]
+
+  permissions {
+    data_actions = ["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/*"]
+  }
+}
+
+resource "azurerm_cosmosdb_sql_role_assignment" "webapp" {
+  resource_group_name = var.resource_group_name
+  account_name        = var.cosmos_account_name
+  role_definition_id  = azurerm_cosmosdb_sql_role_definition.webapp.id
+  principal_id        = azurerm_linux_web_app.app.identity[0].principal_id
+  scope               = "${data.azurerm_cosmosdb_account.state_store.id}/dbs/${azurerm_cosmosdb_sql_database.app.name}"
+}

--- a/apps/app/data.tf
+++ b/apps/app/data.tf
@@ -14,6 +14,8 @@
 
 data "azurerm_client_config" "current" {}
 
+data "azuread_application_published_app_ids" "well_known" {}
+
 data "azurerm_log_analytics_workspace" "core" {
   name                = var.log_analytics_name
   resource_group_name = var.resource_group_name

--- a/apps/app/deploy_workflow_template.yaml
+++ b/apps/app/deploy_workflow_template.yaml
@@ -1,3 +1,4 @@
+---
 name: Deploy ${environment}
 
 on:

--- a/apps/app/github-environment.tf
+++ b/apps/app/github-environment.tf
@@ -184,11 +184,11 @@ resource "github_actions_environment_secret" "webapp_id" {
 }
 
 resource "github_actions_environment_secret" "slot_name" {
-  for_each        = local.branches_and_envs
+  for_each        = local.testing_gh_env != null ? local.branches_and_envs : {}
   repository      = local.github_repository_name
   environment     = each.value
   secret_name     = "SLOT_NAME"
-  plaintext_value = azurerm_linux_web_app_slot.testing.name
+  plaintext_value = local.testing_slot_name
 
   depends_on = [
     github_repository_environment.all

--- a/apps/app/github-environment.tf
+++ b/apps/app/github-environment.tf
@@ -14,7 +14,7 @@
 
 resource "github_branch" "all" {
   for_each   = local.branches_and_envs
-  repository = local.repository_name
+  repository = local.github_repository_name
   branch     = each.key
 
   depends_on = [
@@ -25,7 +25,7 @@ resource "github_branch" "all" {
 
 resource "github_branch_protection" "deployment" {
   for_each            = local.branches_and_envs
-  repository_id       = local.repository_name
+  repository_id       = local.github_repository_name
   pattern             = each.value
   allows_deletions    = false
   allows_force_pushes = false
@@ -49,7 +49,7 @@ resource "github_branch_protection" "deployment" {
 
 resource "github_repository_environment" "all" {
   for_each    = local.branches_and_envs
-  repository  = local.repository_name
+  repository  = local.github_repository_name
   environment = each.value
 
   deployment_branch_policy {
@@ -60,7 +60,7 @@ resource "github_repository_environment" "all" {
   # TODO: remove when https://github.com/integrations/terraform-provider-github/pull/1530 is merged
   provisioner "local-exec" {
     command = <<EOF
-curl https://api.github.com/repos/${var.github_owner}/${local.repository_name}/environments/${each.value}/deployment-branch-policies \
+curl https://api.github.com/repos/${var.github_owner}/${local.github_repository_name}/environments/${each.value}/deployment-branch-policies \
   -H "Accept: application/vnd.github+json" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   -H "Authorization: Bearer ${var.github_access_token}" \
@@ -75,7 +75,7 @@ EOF
 
 resource "github_actions_environment_secret" "acr_name" {
   for_each        = local.branches_and_envs
-  repository      = local.repository_name
+  repository      = local.github_repository_name
   environment     = each.value
   secret_name     = "ACR_NAME"
   plaintext_value = data.azurerm_container_registry.serve.name
@@ -87,7 +87,7 @@ resource "github_actions_environment_secret" "acr_name" {
 
 resource "github_actions_environment_secret" "acr_token_username" {
   for_each        = local.branches_and_envs
-  repository      = local.repository_name
+  repository      = local.github_repository_name
   environment     = each.value
   secret_name     = "ACR_USERNAME"
   plaintext_value = azurerm_container_registry_token.app_access.name
@@ -99,7 +99,7 @@ resource "github_actions_environment_secret" "acr_token_username" {
 
 resource "github_actions_environment_secret" "acr_token_password" {
   for_each        = local.branches_and_envs
-  repository      = local.repository_name
+  repository      = local.github_repository_name
   environment     = each.value
   secret_name     = "ACR_PASSWORD"
   plaintext_value = azurerm_container_registry_token_password.app_access.password1[0].value
@@ -111,7 +111,7 @@ resource "github_actions_environment_secret" "acr_token_password" {
 
 resource "github_actions_environment_secret" "acr_image_name" {
   for_each        = local.branches_and_envs
-  repository      = local.repository_name
+  repository      = local.github_repository_name
   environment     = each.value
   secret_name     = "IMAGE_NAME"
   plaintext_value = local.acr_repository
@@ -125,7 +125,7 @@ resource "github_actions_environment_secret" "acr_image_name" {
 # docker version tag and in the production slot to slot swap
 resource "github_actions_environment_secret" "sp_client_id" {
   for_each        = local.testing_gh_env != null ? local.branches_and_envs : {}
-  repository      = local.repository_name
+  repository      = local.github_repository_name
   environment     = each.value
   secret_name     = "ARM_CLIENT_ID"
   plaintext_value = azuread_application.webapp_sp[0].application_id
@@ -137,7 +137,7 @@ resource "github_actions_environment_secret" "sp_client_id" {
 
 resource "github_actions_environment_secret" "sp_client_secret" {
   for_each        = local.testing_gh_env != null ? local.branches_and_envs : {}
-  repository      = local.repository_name
+  repository      = local.github_repository_name
   environment     = each.value
   secret_name     = "ARM_CLIENT_SECRET"
   plaintext_value = azuread_application_password.webapp_sp[0].value
@@ -149,7 +149,7 @@ resource "github_actions_environment_secret" "sp_client_secret" {
 
 resource "github_actions_environment_secret" "tenant_id" {
   for_each        = local.testing_gh_env != null ? local.branches_and_envs : {}
-  repository      = local.repository_name
+  repository      = local.github_repository_name
   environment     = each.value
   secret_name     = "ARM_TENANT_ID"
   plaintext_value = data.azurerm_client_config.current.tenant_id
@@ -161,7 +161,7 @@ resource "github_actions_environment_secret" "tenant_id" {
 
 resource "github_actions_environment_secret" "subscription_id" {
   for_each        = local.testing_gh_env != null ? local.branches_and_envs : {}
-  repository      = local.repository_name
+  repository      = local.github_repository_name
   environment     = each.value
   secret_name     = "ARM_SUBSCRIPTION_ID"
   plaintext_value = data.azurerm_client_config.current.subscription_id
@@ -173,7 +173,7 @@ resource "github_actions_environment_secret" "subscription_id" {
 
 resource "github_actions_environment_secret" "webapp_id" {
   for_each        = local.testing_gh_env != null ? local.branches_and_envs : {}
-  repository      = local.repository_name
+  repository      = local.github_repository_name
   environment     = each.value
   secret_name     = "WEBAPP_ID"
   plaintext_value = azurerm_linux_web_app.app.id
@@ -185,7 +185,7 @@ resource "github_actions_environment_secret" "webapp_id" {
 
 resource "github_actions_environment_secret" "slot_name" {
   for_each        = local.branches_and_envs
-  repository      = local.repository_name
+  repository      = local.github_repository_name
   environment     = each.value
   secret_name     = "SLOT_NAME"
   plaintext_value = azurerm_linux_web_app_slot.testing.name
@@ -197,7 +197,7 @@ resource "github_actions_environment_secret" "slot_name" {
 
 resource "github_repository_file" "deploy_workflows" {
   for_each            = local.envs_and_workflow_templates
-  repository          = local.repository_name
+  repository          = local.github_repository_name
   branch              = "main"
   file                = ".github/workflows/deploy_${each.key}.yml"
   content             = each.value.rendered

--- a/apps/app/github-environment.tf
+++ b/apps/app/github-environment.tf
@@ -39,7 +39,7 @@ resource "github_branch_protection" "deployment" {
     dismiss_stale_reviews           = var.accesses_real_data ? true : var.app_config.branch.dismiss_stale_reviews
     restrict_dismissals             = var.accesses_real_data
     require_code_owner_reviews      = var.accesses_real_data
-    required_approving_review_count = max(var.app_config.branch.num_of_approvals, 1)
+    required_approving_review_count = var.app_config.branch.num_of_approvals
   }
 
   depends_on = [

--- a/apps/app/github-repository.tf
+++ b/apps/app/github-repository.tf
@@ -44,13 +44,13 @@ resource "github_team_members" "owners" {
 resource "github_team_repository" "owners_repo_permissions" {
   count      = local.create_repo ? 1 : 0
   team_id    = github_team.owners[0].id
-  repository = local.repository_name
+  repository = local.github_repository_name
   permission = "push"
 }
 
 resource "github_repository_file" "codeowners" {
   count               = local.create_repo ? 1 : 0
-  repository          = local.repository_name
+  repository          = local.github_repository_name
   branch              = "main"
   file                = "CODEOWNERS"
   content             = <<EOF
@@ -88,6 +88,6 @@ resource "github_team_members" "contributors" {
 resource "github_team_repository" "contributors_repo_permissions" {
   count      = local.create_repo ? 1 : 0
   team_id    = github_team.contributors[0].id
-  repository = local.repository_name
+  repository = local.github_repository_name
   permission = "push"
 }

--- a/apps/app/github-repository.tf
+++ b/apps/app/github-repository.tf
@@ -1,0 +1,93 @@
+#  Copyright (c) University College London Hospitals NHS Foundation Trust
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+resource "github_repository" "app" {
+  count       = local.create_repo ? 1 : 0
+  name        = var.app_id
+  description = var.app_config.description
+  visibility  = var.app_config.managed_repo.private ? "private" : "public"
+
+  template {
+    owner      = split("/", var.app_config.managed_repo.template)[0]
+    repository = split("/", var.app_config.managed_repo.template)[1]
+  }
+}
+
+resource "github_team" "owners" {
+  count       = local.create_repo ? 1 : 0
+  name        = "${var.app_id} - owners"
+  description = "Owners of the ${var.app_id} FlowEHR app with push and PR/deployment approval permissions."
+  privacy     = "closed"
+}
+
+resource "github_team_members" "owners" {
+  for_each = local.create_repo ? var.app_config.owners : null
+  team_id  = github_team.owners[0].id
+
+  members {
+    username = each.key
+    role     = "maintainer"
+  }
+}
+
+resource "github_team_repository" "owners_repo_permissions" {
+  count      = local.create_repo ? 1 : 0
+  team_id    = github_team.owners[0].id
+  repository = local.repository_name
+  permission = "push"
+}
+
+resource "github_repository_file" "codeowners" {
+  count               = local.create_repo ? 1 : 0
+  repository          = local.repository_name
+  branch              = "main"
+  file                = "CODEOWNERS"
+  content             = <<EOF
+# Owners for branch protection
+# Users within this team are required reviewers for this deployment branch
+*       @${var.github_owner}/${github_team.owners[0].slug}
+EOF
+  commit_message      = "Add codeowners (managed by Terraform)"
+  commit_author       = "Terraform"
+  commit_email        = "terraform@flowehr.io"
+  overwrite_on_create = true
+
+  depends_on = [
+    github_repository.app
+  ]
+}
+
+resource "github_team" "contributors" {
+  count       = local.create_repo ? 1 : 0
+  name        = "${var.app_id} - contributors"
+  description = "Contributors to the ${var.app_id} FlowEHR app with push permissions."
+  privacy     = "closed"
+}
+
+resource "github_team_members" "contributors" {
+  for_each = local.create_repo ? var.app_config.contributors : null
+  team_id  = github_team.contributors[0].id
+
+  members {
+    username = each.key
+    role     = "member"
+  }
+}
+
+resource "github_team_repository" "contributors_repo_permissions" {
+  count      = local.create_repo ? 1 : 0
+  team_id    = github_team.contributors[0].id
+  repository = local.repository_name
+  permission = "push"
+}

--- a/apps/app/locals.tf
+++ b/apps/app/locals.tf
@@ -24,10 +24,13 @@ locals {
   testing_gh_env      = var.app_config.add_testing_slot ? "${var.environment}-testing_slot" : null
   testing_branch_name = local.testing_gh_env
 
+  webapp_name              = "webapp-${replace(var.app_id, "_", "-")}-${var.naming_suffix}"
+  testing_slot_webapp_name = "${local.webapp_name}-testing"
+
   webapp_names = (
     var.app_config.add_testing_slot
-    ? toset([azurerm_linux_web_app.app.name, azurerm_linux_web_app_slot.testing.name])
-    : toset([azurerm_linux_web_app.app.name])
+    ? toset([local.webapp_name, local.testing_slot_webapp_name])
+    : toset([local.webapp_name])
   )
 
   branches_and_envs = var.app_config.add_testing_slot ? {

--- a/apps/app/locals.tf
+++ b/apps/app/locals.tf
@@ -19,7 +19,6 @@ locals {
   acr_repository     = var.app_id
   create_repo        = var.app_config.managed_repo != null
 
-  testing_slot_name   = "testing"
   core_gh_env         = var.environment
   core_branch_name    = local.core_gh_env
   testing_gh_env      = var.app_config.add_testing_slot ? "${var.environment}-testing_slot" : null
@@ -38,7 +37,6 @@ locals {
     "${local.testing_gh_env}" = data.template_file.testing_github_workflow[0]
   } : { "${local.core_gh_env}" = data.template_file.core_github_workflow }
 
-  webapp_name_in_webhook   = lower(azurerm_linux_web_app.app.name)
   site_credential_name     = azurerm_linux_web_app.app.site_credential[0].name
   site_credential_password = azurerm_linux_web_app.app.site_credential[0].password
 }

--- a/apps/app/locals.tf
+++ b/apps/app/locals.tf
@@ -25,14 +25,21 @@ locals {
   testing_branch_name = local.testing_gh_env
 
   webapp_name              = "webapp-${replace(var.app_id, "_", "-")}-${var.naming_suffix}"
-  testing_slot_webapp_name = "${local.webapp_name}-testing"
+  testing_slot_name        = "testing"
+  testing_slot_webapp_name = "${local.webapp_name}-${local.testing_slot_name}"
 
-  webapp_names = (
-    var.app_config.add_testing_slot
-    ? toset([local.webapp_name, local.testing_slot_webapp_name])
-    : toset([local.webapp_name])
+  # List webapp names (main and slots) that require auth to be enabled
+  auth_webapp_names = (
+    var.app_config.require_auth
+    ? (
+      var.app_config.add_testing_slot
+      ? toset([local.webapp_name, local.testing_slot_webapp_name])
+      : toset([local.webapp_name])
+    )
+    : null
   )
 
+  # Map deployment branch and github environment names for main & testing slot (if enabled)
   branches_and_envs = var.app_config.add_testing_slot ? {
     "${local.core_branch_name}"    = local.core_gh_env
     "${local.testing_branch_name}" = local.testing_gh_env
@@ -41,6 +48,7 @@ locals {
   acr_deploy_reusable_workflow_filename = "acr_deploy_reusable.yml"
   slot_swap_reusable_workflow_filename  = "slot_swap_reusable.yml"
 
+  # Map GitHub/FlowEHR environments and corresponding GH workflow files to deploy to them
   envs_and_workflow_templates = var.app_config.add_testing_slot ? {
     "${local.core_gh_env}"    = data.template_file.core_github_workflow
     "${local.testing_gh_env}" = data.template_file.testing_github_workflow[0]

--- a/apps/app/locals.tf
+++ b/apps/app/locals.tf
@@ -13,7 +13,7 @@
 #  limitations under the License.
 
 locals {
-  repository_name = var.app_id
+  github_repository_name = var.app_id
 
   feature_store_odbc = "Driver={ODBC Driver 18 for SQL Server};Server=tcp:${data.azurerm_mssql_server.feature_store.fully_qualified_domain_name},1433;Database=${var.feature_store_db_name};Authentication=ActiveDirectoryMsi;Encrypt=yes;TrustServerCertificate=no;Connection Timeout=30;"
   acr_repository     = var.app_id

--- a/apps/app/locals.tf
+++ b/apps/app/locals.tf
@@ -24,6 +24,12 @@ locals {
   testing_gh_env      = var.app_config.add_testing_slot ? "${var.environment}-testing_slot" : null
   testing_branch_name = local.testing_gh_env
 
+  webapp_names = (
+    var.app_config.add_testing_slot
+    ? toset([azurerm_linux_web_app.app.name, azurerm_linux_web_app_slot.testing.name])
+    : toset([azurerm_linux_web_app.app.name])
+  )
+
   branches_and_envs = var.app_config.add_testing_slot ? {
     "${local.core_branch_name}"    = local.core_gh_env
     "${local.testing_branch_name}" = local.testing_gh_env

--- a/apps/app/variables.tf
+++ b/apps/app/variables.tf
@@ -108,6 +108,7 @@ variable "app_config" {
     name             = string
     description      = optional(string, "Created by FlowEHR")
     add_testing_slot = optional(bool, false)
+    require_auth     = optional(bool, true)
     owners           = map(string)
     contributors     = map(string)
 

--- a/apps/app/webapp.tf
+++ b/apps/app/webapp.tf
@@ -60,13 +60,14 @@ resource "azurerm_linux_web_app" "app" {
   }
 
   dynamic "auth_settings" {
-    count = var.app_config.require_auth ? 1 : 0
+    for_each = contains(local.auth_webapp_names, local.webapp_name) ? [1] : []
 
     content {
       enabled = true
 
       active_directory {
-        client_id = azuread_application.webapp_auth[local.webapp_name].application_id
+        client_id     = azuread_application.webapp_auth[local.webapp_name].application_id
+        client_secret = azuread_application_password.webapp_auth[local.webapp_name].value
       }
     }
   }
@@ -87,7 +88,7 @@ resource "azurerm_linux_web_app" "app" {
 
 resource "azurerm_linux_web_app_slot" "testing" {
   count          = var.app_config.add_testing_slot ? 1 : 0
-  name           = "testing"
+  name           = local.testing_slot_name
   app_service_id = azurerm_linux_web_app.app.id
   https_only     = true
 
@@ -113,13 +114,14 @@ resource "azurerm_linux_web_app_slot" "testing" {
   }
 
   dynamic "auth_settings" {
-    count = var.app_config.require_auth ? 1 : 0
+    for_each = contains(local.auth_webapp_names, local.testing_slot_webapp_name) ? [1] : []
 
     content {
       enabled = true
 
       active_directory {
-        client_id = azuread_application.webapp_auth[local.testing_slot_webapp_name].application_id
+        client_id     = azuread_application.webapp_auth[local.testing_slot_webapp_name].application_id
+        client_secret = azuread_application_password.webapp_auth[local.testing_slot_webapp_name].value
       }
     }
   }

--- a/apps/app/webapp.tf
+++ b/apps/app/webapp.tf
@@ -23,7 +23,7 @@ resource "azurerm_application_insights" "app" {
 }
 
 resource "azurerm_linux_web_app" "app" {
-  name                      = "webapp-${replace(var.app_id, "_", "-")}-${var.naming_suffix}"
+  name                      = local.webapp_name
   resource_group_name       = var.resource_group_name
   location                  = var.location
   service_plan_id           = data.azurerm_service_plan.serve.id
@@ -57,6 +57,18 @@ resource "azurerm_linux_web_app" "app" {
 
   identity {
     type = "SystemAssigned"
+  }
+
+  dynamic "auth_settings" {
+    count = var.app_config.require_auth ? 1 : 0
+
+    content {
+      enabled = true
+
+      active_directory {
+        client_id = azuread_application.webapp_auth[local.webapp_name].application_id
+      }
+    }
   }
 
   logs {
@@ -98,6 +110,18 @@ resource "azurerm_linux_web_app_slot" "testing" {
 
   identity {
     type = "SystemAssigned"
+  }
+
+  dynamic "auth_settings" {
+    count = var.app_config.require_auth ? 1 : 0
+
+    content {
+      enabled = true
+
+      active_directory {
+        client_id = azuread_application.webapp_auth[local.testing_slot_webapp_name].application_id
+      }
+    }
   }
 
   logs {

--- a/apps/app/webapp.tf
+++ b/apps/app/webapp.tf
@@ -66,8 +66,7 @@ resource "azurerm_linux_web_app" "app" {
       enabled = true
 
       active_directory {
-        client_id     = azuread_application.webapp_auth[local.webapp_name].application_id
-        client_secret = azuread_application_password.webapp_auth[local.webapp_name].value
+        client_id = azuread_application.webapp_auth[local.webapp_name].application_id
       }
     }
   }
@@ -120,8 +119,7 @@ resource "azurerm_linux_web_app_slot" "testing" {
       enabled = true
 
       active_directory {
-        client_id     = azuread_application.webapp_auth[local.testing_slot_webapp_name].application_id
-        client_secret = azuread_application_password.webapp_auth[local.testing_slot_webapp_name].value
+        client_id = azuread_application.webapp_auth[local.testing_slot_webapp_name].application_id
       }
     }
   }

--- a/apps/app/webapp.tf
+++ b/apps/app/webapp.tf
@@ -67,7 +67,8 @@ resource "azurerm_linux_web_app" "app" {
       issuer  = "https://login.microsoftonline.com/${data.azurerm_client_config.current.tenant_id}/v2.0"
 
       active_directory {
-        client_id = azuread_application.webapp_auth[local.webapp_name].application_id
+        client_id     = azuread_application.webapp_auth[local.webapp_name].application_id
+        client_secret = azuread_application_password.webapp_auth[local.webapp_name].value
       }
     }
   }
@@ -121,7 +122,8 @@ resource "azurerm_linux_web_app_slot" "testing" {
       issuer  = "https://login.microsoftonline.com/${data.azurerm_client_config.current.tenant_id}/v2.0"
 
       active_directory {
-        client_id = azuread_application.webapp_auth[local.testing_slot_webapp_name].application_id
+        client_id     = azuread_application.webapp_auth[local.testing_slot_webapp_name].application_id
+        client_secret = azuread_application_password.webapp_auth[local.testing_slot_webapp_name].value
       }
     }
   }

--- a/apps/app/webapp.tf
+++ b/apps/app/webapp.tf
@@ -75,7 +75,7 @@ resource "azurerm_linux_web_app" "app" {
 
 resource "azurerm_linux_web_app_slot" "testing" {
   count          = var.app_config.add_testing_slot ? 1 : 0
-  name           = local.testing_slot_name
+  name           = "testing"
   app_service_id = azurerm_linux_web_app.app.id
   https_only     = true
 
@@ -112,62 +112,6 @@ resource "azurerm_linux_web_app_slot" "testing" {
       }
     }
   }
-}
-
-resource "azurerm_role_assignment" "webapp_acr" {
-  role_definition_name = "AcrPull"
-  scope                = data.azurerm_container_registry.serve.id
-  principal_id         = azurerm_linux_web_app.app.identity[0].principal_id
-}
-
-resource "azurerm_role_assignment" "webapp_testing_slot_acr" {
-  count                = var.app_config.add_testing_slot ? 1 : 0
-  role_definition_name = "AcrPull"
-  scope                = data.azurerm_container_registry.serve.id
-  principal_id         = azurerm_linux_web_app_slot.testing[0].identity[0].principal_id
-}
-
-# Create a web hook that triggers automated deployment of the Docker image
-resource "azurerm_container_registry_webhook" "webhook" {
-  count               = var.app_config.add_testing_slot ? 0 : 1
-  name                = "acrwh${replace(replace(var.app_id, "_", ""), "-", "")}"
-  resource_group_name = var.resource_group_name
-  location            = var.location
-  registry_name       = data.azurerm_container_registry.serve.name
-
-  service_uri = "https://${local.site_credential_name}:${local.site_credential_password}@${local.webapp_name_in_webhook}.scm.azurewebsites.net/api/registry/webhook"
-  status      = "enabled"
-  scope       = "${local.acr_repository}:latest"
-  actions     = ["push"]
-
-  custom_headers = {
-    "Content-Type" = "application/json"
-  }
-}
-
-resource "azurerm_cosmosdb_sql_database" "app" {
-  name                = "${var.app_id}-state"
-  resource_group_name = var.resource_group_name
-  account_name        = var.cosmos_account_name
-}
-
-resource "azurerm_cosmosdb_sql_role_definition" "webapp" {
-  name                = "${var.app_id}-AccessCosmosSingleDB"
-  resource_group_name = var.resource_group_name
-  account_name        = var.cosmos_account_name
-  assignable_scopes   = ["${data.azurerm_cosmosdb_account.state_store.id}/dbs/${azurerm_cosmosdb_sql_database.app.name}"]
-
-  permissions {
-    data_actions = ["Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers/*"]
-  }
-}
-
-resource "azurerm_cosmosdb_sql_role_assignment" "webapp" {
-  resource_group_name = var.resource_group_name
-  account_name        = var.cosmos_account_name
-  role_definition_id  = azurerm_cosmosdb_sql_role_definition.webapp.id
-  principal_id        = azurerm_linux_web_app.app.identity[0].principal_id
-  scope               = "${data.azurerm_cosmosdb_account.state_store.id}/dbs/${azurerm_cosmosdb_sql_database.app.name}"
 }
 
 resource "azuread_application" "webapp_sp" {

--- a/apps/app/webapp.tf
+++ b/apps/app/webapp.tf
@@ -64,6 +64,7 @@ resource "azurerm_linux_web_app" "app" {
 
     content {
       enabled = true
+      issuer  = "https://login.microsoftonline.com/${data.azurerm_client_config.current.tenant_id}/v2.0"
 
       active_directory {
         client_id = azuread_application.webapp_auth[local.webapp_name].application_id
@@ -117,6 +118,7 @@ resource "azurerm_linux_web_app_slot" "testing" {
 
     content {
       enabled = true
+      issuer  = "https://login.microsoftonline.com/${data.azurerm_client_config.current.tenant_id}/v2.0"
 
       active_directory {
         client_id = azuread_application.webapp_auth[local.testing_slot_webapp_name].application_id

--- a/apps/apps.sample.yaml
+++ b/apps/apps.sample.yaml
@@ -1,16 +1,17 @@
 ---
-dash_seedling: # unique ID for the app
-  name: Dash Seedling # friendly name
-  description: Hello world app for Dash # short description
-  add_testing_slot: false # Whether to add a testing slot in addition to main slot
-  owners: # Owners to add to repo (for reviews) in format GH_USERNAME: AAD_EMAIL
+dash_seedling:  # unique ID for the app
+  name: Dash Seedling  # friendly name
+  description: Hello world app for Dash  # short description
+  add_testing_slot: false  # Whether to add a testing slot in addition to main slot
+  require_auth: false  # Whether to require end-users to authenticate with AAD to access app
+  owners:  # Owners to add to repo (for reviews) in format GH_USERNAME: AAD_EMAIL
     octocat: an_aad_user@mycompany.com
-  contributors: # contributors to add to repo in format GH_USERNAME: AAD_EMAIL
+  contributors:  # contributors to add to repo in format GH_USERNAME: AAD_EMAIL
     octokitten: an_aad_user@mycompany.com
-  managed_repo: # details for repo to create/manage
-    private: false # repo visibility
-    template: UCLH-Foundry/Dash-Seedling # template to use in format GH_ORG/TEMPLATE_NAME
-  branch: # details of the branch created with a name: <environment>
+  managed_repo:  # details for repo to create/manage
+    private: false  # repo visibility
+    template: UCLH-Foundry/Dash-Seedling  # template to use in format GH_ORG/TEMPLATE_NAME
+  branch:  # details of the branch created with a name: <environment>
     num_of_approvals: 1
-  env: # any env vars to pass to the app container
+  env:  # any env vars to pass to the app container
     WEBSITES_PORT: 8000


### PR DESCRIPTION
# Resolves #175 

## What is being addressed

Adds app authentication via Terraform using V1 block to avoid needing manually REST API calls for the v2 workaround (https://github.com/UCLH-Foundry/FlowEHR/pull/200)

## How is this addressed

- Add AD apps for main and testing slots (if enabled) with relevant web oauth2 settings
- Link these to `auth_settings` blocks on web apps / slots
- Separates out large tf files into smaller logical sections

## Has the CIS document been consulted / updated?

- `Enable App Service Authentication is set up`: `TODO` -> `Y`
