### PR TITLE
Dbks potential cluster bootstrap fix

### DIFF
--- a/infrastructure/transform/databricks-udr-ips.yaml
+++ b/infrastructure/transform/databricks-udr-ips.yaml
@@ -1,0 +1,107 @@
+---
+australiacentral:
+  extinfra:
+    - 20.53.145.128/28
+australiacentral2:
+  extinfra:
+    - 20.53.145.128/28
+australiaeast:
+  extinfra:
+    - 20.53.145.128/28
+brazilsouth:
+  extinfra:
+    - 20.197.222.144/28
+canadacentral:
+  extinfra:
+    - 52.139.4.160/28
+canadaeast:
+  extinfra:
+    - 52.139.4.160/28
+centralindia:
+  extinfra:
+    - 20.193.246.208/28
+centralus:
+  extinfra:
+    - 20.57.106.0/28
+eastasia:
+  extinfra:
+    - 20.195.104.64/28
+    - 20.239.100.80/28
+eastus:
+  extinfra:
+    - 20.57.106.0/28
+eastus2:
+  extinfra:
+    - 20.57.106.0/28
+francecentral:
+  extinfra:
+    - 20.74.69.128/28
+germanywestcentral:
+  extinfra:
+    - 20.52.93.40/29
+japaneast:
+  extinfra:
+    - 20.78.226.176/28
+japanwest:
+  extinfra:
+    - 20.78.226.176/28
+koreacentral:
+  extinfra:
+    - 20.194.107.48/28
+northcentralus:
+  extinfra:
+    - 20.57.106.0/28
+northeurope:
+  extinfra:
+    - 20.73.215.48/28
+norwayeast:
+  extinfra:
+    - 51.13.86.224/28
+southafricanorth:
+  extinfra:
+    - 102.133.192.48/28
+southcentralus:
+  extinfra:
+    - 13.91.84.96/28
+southindia:
+  extinfra:
+    - 20.193.246.208/28
+southeastasia:
+  extinfra:
+    - 20.195.104.64/28
+swedencentral:
+  extinfra:
+    - 20.91.164.16/28
+switzerlandnorth:
+  extinfra:
+    - 51.103.172.176/28
+switzerlandwest:
+  extinfra:
+    - 51.107.233.80/28
+uaenorth:
+  extinfra:
+    - 40.120.89.0/28
+uksouth:
+  extinfra:
+    - 51.141.64.128/28
+ukwest:
+  extinfra:
+    - 51.141.64.128/28
+westcentralus:
+  extinfra:
+    - 52.161.34.0/28
+westeurope:
+  extinfra:
+    - 20.73.215.48/28
+westindia:
+  extinfra:
+    - 20.193.246.208/28
+westus:
+  extinfra:
+    - 13.91.84.96/28
+westus2:
+  extinfra:
+    - 13.91.84.96/28
+westus3:
+  extinfra:
+    - 20.125.82.0/28

--- a/infrastructure/transform/databricks.tf
+++ b/infrastructure/transform/databricks.tf
@@ -38,7 +38,9 @@ resource "azurerm_databricks_workspace" "databricks" {
     azurerm_subnet_network_security_group_association.databricks_host,
     azurerm_subnet_network_security_group_association.databricks_container,
     azurerm_subnet_route_table_association.databricks_host,
-    azurerm_subnet_route_table_association.databricks_container
+    azurerm_subnet_route_table_association.databricks_container,
+    azurerm_private_dns_zone_virtual_network_link.databricks,
+    azurerm_private_dns_zone_virtual_network_link.azure_platform
   ]
 }
 

--- a/infrastructure/transform/databricks.tf
+++ b/infrastructure/transform/databricks.tf
@@ -36,7 +36,9 @@ resource "azurerm_databricks_workspace" "databricks" {
 
   depends_on = [
     azurerm_subnet_network_security_group_association.databricks_host,
-    azurerm_subnet_network_security_group_association.databricks_container
+    azurerm_subnet_network_security_group_association.databricks_container,
+    azurerm_subnet_route_table_association.databricks_host,
+    azurerm_subnet_route_table_association.databricks_container
   ]
 }
 

--- a/infrastructure/transform/databricks.tf
+++ b/infrastructure/transform/databricks.tf
@@ -35,12 +35,9 @@ resource "azurerm_databricks_workspace" "databricks" {
   }
 
   depends_on = [
-    azurerm_subnet_network_security_group_association.databricks_host,
-    azurerm_subnet_network_security_group_association.databricks_container,
     azurerm_subnet_route_table_association.databricks_host,
     azurerm_subnet_route_table_association.databricks_container,
-    azurerm_private_dns_zone_virtual_network_link.databricks,
-    azurerm_private_dns_zone_virtual_network_link.azure_platform
+    azurerm_private_dns_zone_virtual_network_link.databricks
   ]
 }
 

--- a/infrastructure/transform/locals.tf
+++ b/infrastructure/transform/locals.tf
@@ -21,6 +21,17 @@ locals {
   artifacts_dir                      = "artifacts"
   adb_linked_service_name            = "ADBLinkedServiceViaMSI"
 
+  # IPs required for Databricks UDRs 
+  # Built from https://learn.microsoft.com/en-us/azure/databricks/resources/supported-regions#--control-plane-nat-webapp-and-extended-infrastructure-ip-addresses-and-domains
+  databricks_udr_ips   = yamldecode(file("${path.module}/databricks-udr-ips.yaml"))
+  title_cased_location = title(var.core_rg_location)
+  databricks_service_tags = {
+    "databricks" : "AzureDatabricks",
+    "sql" : "Sql.${local.title_cased_location}",
+    "storage" : "Storage.${local.title_cased_location}",
+    "eventhub" : "EventHub.${local.title_cased_location}"
+  }
+
   all_pipeline_files = fileset(path.module, "../../transform/pipelines/**/${local.pipeline_file}")
 
   # Example value: [ "../../transform/pipelines/hello-world" ]

--- a/infrastructure/transform/network.tf
+++ b/infrastructure/transform/network.tf
@@ -158,8 +158,11 @@ resource "azurerm_private_endpoint" "databricks_control_plane" {
   }
 
   private_dns_zone_group {
-    name                 = "private-dns-zone-group-databricks-control-plane-${var.naming_suffix}"
-    private_dns_zone_ids = [azurerm_private_dns_zone.databricks.id]
+    name = "private-dns-zone-group-databricks-control-plane-${var.naming_suffix}"
+    private_dns_zone_ids = [
+      azurerm_private_dns_zone.databricks.id,
+      azurerm_private_dns_zone.azure_platform.id
+    ]
   }
 }
 

--- a/infrastructure/transform/network.tf
+++ b/infrastructure/transform/network.tf
@@ -119,10 +119,26 @@ resource "azurerm_private_dns_zone" "databricks" {
   tags                = var.tags
 }
 
+# Need for proper DNS resolution between Databricks & platform services
+# https://learn.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16
+resource "azurerm_private_dns_zone" "azure_platform" {
+  name                = "168.63.129.16"
+  resource_group_name = var.core_rg_name
+  tags                = var.tags
+}
+
 resource "azurerm_private_dns_zone_virtual_network_link" "databricks" {
   name                  = "vnl-dbks-${var.naming_suffix}"
   resource_group_name   = var.core_rg_name
   private_dns_zone_name = azurerm_private_dns_zone.databricks.name
+  virtual_network_id    = data.azurerm_virtual_network.core.id
+  tags                  = var.tags
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "azure_platform" {
+  name                  = "vnl-azplatform-${var.naming_suffix}"
+  resource_group_name   = var.core_rg_name
+  private_dns_zone_name = azurerm_private_dns_zone.azure_platform.name
   virtual_network_id    = data.azurerm_virtual_network.core.id
   tags                  = var.tags
 }

--- a/infrastructure/transform/network.tf
+++ b/infrastructure/transform/network.tf
@@ -87,6 +87,15 @@ resource "azurerm_route" "databricks_service_tags" {
   next_hop_type       = "Internet"
 }
 
+resource "azurerm_route" "databricks_extinfra_ips" {
+  for_each            = try(toset(local.databricks_udr_ips[var.core_rg_location].extinfra), toset([]))
+  name                = "extinfra-${index(local.databricks_udr_ips[var.core_rg_location].extinfra, each.value)}"
+  resource_group_name = var.core_rg_name
+  route_table_name    = azurerm_route_table.databricks_udrs.name
+  address_prefix      = each.value
+  next_hop_type       = "Internet"
+}
+
 resource "azurerm_subnet_route_table_association" "databricks_container" {
   subnet_id      = azurerm_subnet.databricks_container.id
   route_table_id = azurerm_route_table.databricks_udrs.id


### PR DESCRIPTION
# Resolves #141

## What is being addressed

This (hopefully) fixes the repeated issues we've seen when trying to deploy clusters. Following some investigation with the help of a support engineer, the reason why we might be seeing this only in the uksouth region currently is because each region has different IPs for various dependencies Databricks relies on and the routing might be clashing with other resources we have set up.

## How is this addressed

As per https://learn.microsoft.com/en-gb/azure/databricks/administration-guide/cloud-configurations/azure/udr?WT.mc_id=Portal-Microsoft_Azure_Support#--configure-user-defined-routes-with-azure-service-tags I've added a routing table with some service tags for these dependencies to ensure the routing happens correctly each time.

In my testing I've encountered no issues in uksouth however only time will tell.