### PR TITLE
Add rt association to core shared subnet

### DIFF
--- a/infrastructure/transform/network.tf
+++ b/infrastructure/transform/network.tf
@@ -106,6 +106,11 @@ resource "azurerm_subnet_route_table_association" "databricks_host" {
   route_table_id = azurerm_route_table.databricks_udrs.id
 }
 
+resource "azurerm_subnet_route_table_association" "shared" {
+  subnet_id      = var.core_subnet_id
+  route_table_id = azurerm_route_table.databricks_udrs.id
+}
+
 resource "azurerm_private_dns_zone" "databricks" {
   name                = "privatelink.azuredatabricks.net"
   resource_group_name = var.core_rg_name


### PR DESCRIPTION
# Resolves #141

## What is being addressed

Had an issue re-occur on one of my deployments and spent some more time with the support engineer today. After lots of `nslookup`ing think we may have got to the bottom of it. Because we're using private link for databricks and that exists within the shared/core subnet, we also need to associate the new Databricks UDRs Route Table to that subnet (previously was associated to just the databricks container and host subnets) so that the proper flow to the cluster relay can happen. Testing so far seems to be promising but let's see how it goes.

## How is this addressed

- Added new route table association to core subnet

