### PR TITLE
Add terragrunt retryable errors

### DIFF
--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -99,6 +99,7 @@ inputs = merge(
 
 # Databricks cluster deployment failures are transient. https://github.com/UCLH-Foundry/FlowEHR/issues/141
 retryable_errors = [
-  "Error: cannot create cluster",  # databricks
-  "not ready for container group"  # vnet not ready for container group
+  "Error: cannot create cluster",       # databricks
+  "not ready for container group",      # vnet not ready for container group
+  "Waiting for deletion of application" # AD application
 ]

--- a/terragrunt.hcl
+++ b/terragrunt.hcl
@@ -96,3 +96,9 @@ inputs = merge(
     environment = dependency.bootstrap.outputs.environment
   }
 })
+
+# Databricks cluster deployment failures are transient. https://github.com/UCLH-Foundry/FlowEHR/issues/141
+retryable_errors = [
+  "Error: cannot create cluster",  # databricks
+  "not ready for container group"  # vnet not ready for container group
+]


### PR DESCRIPTION
# Resolves #141 

Using resolves in the loosest possible sense this PR adds a couple of regex patterns for which an retries usually fix the error. Docs: https://terragrunt.gruntwork.io/docs/features/auto-retry/