### PR TITLE
Add correct header to YAML file

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -1,3 +1,4 @@
+---
 flowehr_id: __CHANGE_ME__
 location: __CHANGE_ME__
 environment: __CHANGE_ME__


### PR DESCRIPTION
## What is being addressed

This places the missing YAML header `---` into the `config.sample.yaml` file.
