### PR TITLE
Fix ASP autoscale unsupported metric error

### DIFF
--- a/infrastructure/serve/app_service.tf
+++ b/infrastructure/serve/app_service.tf
@@ -40,6 +40,7 @@ resource "azurerm_monitor_autoscale_setting" "asp" {
       metric_trigger {
         metric_name        = "CpuPercentage"
         metric_resource_id = azurerm_service_plan.serve.id
+        metric_namespace   = "Microsoft.Web/serverfarms"
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"
@@ -60,6 +61,7 @@ resource "azurerm_monitor_autoscale_setting" "asp" {
       metric_trigger {
         metric_name        = "CpuPercentage"
         metric_resource_id = azurerm_service_plan.serve.id
+        metric_namespace   = "Microsoft.Web/serverfarms"
         time_grain         = "PT1M"
         statistic          = "Average"
         time_window        = "PT5M"


### PR DESCRIPTION
For some ~stupid~ curious reason, the autoscale settings for the service ASP has started failing with `UnsupportedMetric` for `CpuPercentage`: https://github.com/UCLH-Foundry/FlowEHR/actions/runs/4676785741/jobs/8283516301#step:9:4664

I've double checked the docs and this is indeed the correct metric for app service autoscale. To try and resolve this, I'm explicitly setting the `metric_namespace` which is optional and should be derived from the resource id, to see if this fixes it.