### PR TITLE
Add flowehr prefix to state & dns zone + makefile fix

### DIFF
--- a/.github/workflows/devcontainer_make_command.yml
+++ b/.github/workflows/devcontainer_make_command.yml
@@ -107,7 +107,7 @@ jobs:
           # https://github.com/devcontainers/ci/issues/231
           SUFFIX_OVERRIDE: ${{ inputs.suffix_override }}
           GH_APP_CERT: ${{ secrets.GH_APP_CERT }}
-          TF_LOG: ${{ (runner.debug == '1' && 'DEBUG') || '' }}
+          TF_LOG: ${{ (runner.debug == '1' && 'INFO') || '' }}
         with:
           imageName: ${{ steps.dc.outputs.image_path }}
           imageTag: ${{ steps.dc.outputs.tag }}

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ define terragrunt  # Arguments: <command>, <folder name>
 		--terragrunt-exclude-dir ${MAKEFILE_DIR}/auth
 endef
 
-all: az-login ## Deploy everything
+all: az-login transform-artifacts ## Deploy everything
 	$(call terragrunt,apply,.)
 
 help: ## Show this help

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ define terragrunt  # Arguments: <command>, <folder name>
 		--terragrunt-exclude-dir ${MAKEFILE_DIR}/auth
 endef
 
-all: az-login transform-artifacts ## Deploy everything
+all: az-login ## Deploy everything
 	$(call terragrunt,apply,.)
 
 help: ## Show this help
@@ -54,13 +54,13 @@ auth: az-login ## Create auth app for deployments
 	&& terraform output -json \
 	  | jq -r 'with_entries(.value |= .value) | to_entries[] | "\(.key +": "+ .value)"'
 
-infrastructure: az-login transform-artifacts ## Deploy all infrastructure
+infrastructure: az-login ## Deploy all infrastructure
 	$(call terragrunt,apply,infrastructure)
 
 infrastructure-core: az-login ## Deploy core infrastructure
 	$(call terragrunt,apply,infrastructure/core)
 
-infrastructure-transform: az-login transform-artifacts ## Deploy transform infrastructure
+infrastructure-transform: az-login ## Deploy transform infrastructure
 	$(call terragrunt,apply,infrastructure/transform)
 
 infrastructure-serve: az-login ## Deploy serve infrastructure

--- a/README.md
+++ b/README.md
@@ -52,12 +52,13 @@ Once you've created it, specify the following values:
       virtual_network_name: name of the virtual network
       resource_group_name: resource group name containing vnet
       dns_zones:
-        - list of dns zones
+        - list of dns zones created in the data source to link to (if private_dns_zones_rg is defined, FlowEHR will look for these in that rg)
     fqdn: fqdn for the datasource (e.g. asqlserver.database.windows.net)
     database: database name
     username: db username
     password: db password
 ```
+
 
 ## Deploying
 

--- a/apps/.terraform.lock.hcl
+++ b/apps/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
   version = "2.37.0"
   hashes = [
     "h1:+ZR0i88QJL1w0nx76Ft92OION4oNliujRWGHwjiVbe4=",
+    "h1:IORur54iMvvKPCjcdLDSfz99fleG4gxuwpqY/ueb6/o=",
     "zh:19fafdb527f31d8c8997d43caf537e1ddcc5f90ca258ec91af48ff5d743a08ec",
     "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
     "zh:238e5e6cdd0201aec1b16e5f7dd9c0aa97c45945d4ad8074fa2199da8218d37d",
@@ -65,6 +66,7 @@ provider "registry.terraform.io/hashicorp/external" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.5.1"
   hashes = [
+    "h1:6FVyQ/aG6tawPam6B+oFjgdidKd83uG9n7dOSQ66HBA=",
     "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",

--- a/apps/main.tf
+++ b/apps/main.tf
@@ -15,6 +15,7 @@
 # TODO: remove when https://github.com/integrations/terraform-provider-github/pull/1530 is merged
 # Needed for manual POST to GitHub APIs and redundant when able to create branch policies in TF
 data "external" "github_access_token" {
+  count = length(var.apps) > 0 ? 1 : 0
   program = [
     "python",
     "${path.module}/generate_gh_token.py",
@@ -47,5 +48,5 @@ module "app" {
   apps_ad_group_principal_id       = var.transform_apps_ad_group_principal_id
   developers_ad_group_principal_id = var.transform_developers_ad_group_principal_id
   github_owner                     = var.serve.github_owner
-  github_access_token              = data.external.github_access_token.result.token
+  github_access_token              = data.external.github_access_token[0].result.token
 }

--- a/apps/terragrunt.hcl
+++ b/apps/terragrunt.hcl
@@ -95,6 +95,7 @@ dependency "core" {
     core_rg_location        = "core_rg_location"
     core_kv_id              = "core_kv_id"
     core_log_analytics_name = "core_log_analytics_name"
+    webapps_subnet_id       = "serve_webapps_subnet_id"
   }
   mock_outputs_allowed_terraform_commands = ["init", "destroy"]
 }
@@ -120,7 +121,6 @@ dependency "serve" {
     app_service_plan_name = "serve_app_service_plan_name"
     acr_name              = "serve_acr_name"
     cosmos_account_name   = "serve_cosmos_account_name"
-    webapps_subnet_id     = "serve_webapps_subnet_id"
   }
   mock_outputs_allowed_terraform_commands = ["init", "destroy"]
 }

--- a/apps/terragrunt.hcl
+++ b/apps/terragrunt.hcl
@@ -89,12 +89,14 @@ dependency "core" {
   config_path = "${get_repo_root()}/infrastructure/core"
 
   mock_outputs = {
+    naming_suffix           = "naming_suffix"
+    naming_suffix_truncated = "naming_suffix_truncated"
     core_rg_name            = "core_rg_name"
     core_rg_location        = "core_rg_location"
     core_kv_id              = "core_kv_id"
     core_log_analytics_name = "core_log_analytics_name"
   }
-  mock_outputs_allowed_terraform_commands = ["destroy"]
+  mock_outputs_allowed_terraform_commands = ["init", "destroy"]
 }
 
 dependency "transform" {
@@ -108,7 +110,7 @@ dependency "transform" {
     apps_ad_group_principal_id       = "transform_apps_ad_group_principal_id"
     developers_ad_group_principal_id = "transform_developers_ad_group_principal_id"
   }
-  mock_outputs_allowed_terraform_commands = ["destroy"]
+  mock_outputs_allowed_terraform_commands = ["init", "destroy"]
 }
 
 dependency "serve" {
@@ -120,7 +122,7 @@ dependency "serve" {
     cosmos_account_name   = "serve_cosmos_account_name"
     webapps_subnet_id     = "serve_webapps_subnet_id"
   }
-  mock_outputs_allowed_terraform_commands = ["destroy"]
+  mock_outputs_allowed_terraform_commands = ["init", "destroy"]
 }
 
 inputs = {

--- a/apps/terragrunt.hcl
+++ b/apps/terragrunt.hcl
@@ -89,15 +89,15 @@ dependency "core" {
   config_path = "${get_repo_root()}/infrastructure/core"
 
   mock_outputs = {
-    naming_suffix                              = "naming_suffix"
-    naming_suffix_truncated                    = "naming_suffix_truncated"
-    core_rg_name                               = "core_rg_name"
-    core_rg_location                           = "core_rg_location"
-    core_kv_id                                 = "core_kv_id"
-    core_log_analytics_name                    = "core_log_analytics_name"
-    webapps_subnet_id                          = "serve_webapps_subnet_id"
-    core_developers_ad_group_principal_id      = "core_developers_ad_group_principal_id"
-    core_data_scientists_ad_group_principal_id = "core_data_scientists_ad_group_principal_id"
+    naming_suffix                         = "naming_suffix"
+    naming_suffix_truncated               = "naming_suffix_truncated"
+    core_rg_name                          = "core_rg_name"
+    core_rg_location                      = "core_rg_location"
+    core_kv_id                            = "core_kv_id"
+    core_log_analytics_name               = "core_log_analytics_name"
+    webapps_subnet_id                     = "serve_webapps_subnet_id"
+    developers_ad_group_principal_id      = "core_developers_ad_group_principal_id"
+    data_scientists_ad_group_principal_id = "core_data_scientists_ad_group_principal_id"
   }
   mock_outputs_allowed_terraform_commands = ["init", "destroy"]
 }

--- a/apps/variables.tf
+++ b/apps/variables.tf
@@ -102,16 +102,18 @@ variable "github_app_cert" {
 
 # -- FROM CONFIGURATION FILES --------
 variable "accesses_real_data" {
-  type = bool
+  type    = bool
+  default = false
 }
 
 variable "serve" {
-  description = "Serve configuration block (populated from root config file(s))"
+  description = "Serve configuration block (populated from root config file(s)). Required when apps are configured for deployment."
   type = object({
     github_owner               = string
     github_app_id              = string
     github_app_installation_id = string
   })
+  default = {} # Set a default so a serve block isn't required when running make all without any apps configured
 }
 
 variable "apps" {

--- a/apps/variables.tf
+++ b/apps/variables.tf
@@ -113,7 +113,12 @@ variable "serve" {
     github_app_id              = string
     github_app_installation_id = string
   })
-  default = {} # Set a default so a serve block isn't required when running make all without any apps configured
+  # Set a default so a serve block isn't required when running make all without any apps configured
+  default = {
+    github_owner               = null
+    github_app_id              = null
+    github_app_installation_id = null
+  }
 }
 
 variable "apps" {

--- a/auth/.terraform.lock.hcl
+++ b/auth/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
   version = "2.37.0"
   hashes = [
     "h1:+ZR0i88QJL1w0nx76Ft92OION4oNliujRWGHwjiVbe4=",
+    "h1:IORur54iMvvKPCjcdLDSfz99fleG4gxuwpqY/ueb6/o=",
     "zh:19fafdb527f31d8c8997d43caf537e1ddcc5f90ca258ec91af48ff5d743a08ec",
     "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
     "zh:238e5e6cdd0201aec1b16e5f7dd9c0aa97c45945d4ad8074fa2199da8218d37d",

--- a/infrastructure/core/.terraform.lock.hcl
+++ b/infrastructure/core/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/azuread" {
   version = "2.37.0"
   hashes = [
     "h1:+ZR0i88QJL1w0nx76Ft92OION4oNliujRWGHwjiVbe4=",
+    "h1:IORur54iMvvKPCjcdLDSfz99fleG4gxuwpqY/ueb6/o=",
     "zh:19fafdb527f31d8c8997d43caf537e1ddcc5f90ca258ec91af48ff5d743a08ec",
     "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
     "zh:238e5e6cdd0201aec1b16e5f7dd9c0aa97c45945d4ad8074fa2199da8218d37d",
@@ -106,6 +107,7 @@ provider "registry.terraform.io/hashicorp/null" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.5.1"
   hashes = [
+    "h1:6FVyQ/aG6tawPam6B+oFjgdidKd83uG9n7dOSQ66HBA=",
     "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
     "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
     "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",

--- a/infrastructure/core/locals.tf
+++ b/infrastructure/core/locals.tf
@@ -24,6 +24,7 @@ locals {
   databricks_container_address_space = local.subnet_address_spaces[2]
   serve_webapps_address_space        = local.subnet_address_spaces[3]
 
+  create_dns_zones = var.private_dns_zones_rg == null
   required_private_dns_zones = {
     blob       = "privatelink.blob.core.windows.net"
     keyvault   = "privatelink.vaultcore.azure.net"

--- a/infrastructure/core/network.tf
+++ b/infrastructure/core/network.tf
@@ -131,7 +131,7 @@ resource "azurerm_virtual_network_peering" "flowehr_to_ci" {
   remote_virtual_network_id = data.azurerm_virtual_network.ci[0].id
 }
 
-# If create_dns_zones is true, we link to the created zones, otherwise link to pre-existing zones
+# If private_dns_zones_rg isn't set, we link to the created zones, otherwise link to pre-existing zones
 resource "azurerm_private_dns_zone_virtual_network_link" "flowehr" {
   for_each              = var.private_dns_zones_rg == null ? azurerm_private_dns_zone.created_zones : data.azurerm_private_dns_zone.existing_zones
   name                  = "vnl-${each.value.name}-flwr-${local.naming_suffix}"

--- a/infrastructure/core/network.tf
+++ b/infrastructure/core/network.tf
@@ -109,7 +109,7 @@ resource "azurerm_subnet" "serve_webapps" {
 }
 
 resource "azurerm_private_dns_zone" "created_zones" {
-  for_each            = var.private_dns_zones_rg == null ? local.required_private_dns_zones : {}
+  for_each            = local.create_dns_zones ? local.required_private_dns_zones : {}
   name                = each.value
   resource_group_name = azurerm_resource_group.core.name
   tags                = var.tags
@@ -133,9 +133,9 @@ resource "azurerm_virtual_network_peering" "flowehr_to_ci" {
 
 # If private_dns_zones_rg isn't set, we link to the created zones, otherwise link to pre-existing zones
 resource "azurerm_private_dns_zone_virtual_network_link" "flowehr" {
-  for_each              = var.private_dns_zones_rg == null ? azurerm_private_dns_zone.created_zones : data.azurerm_private_dns_zone.existing_zones
+  for_each              = local.create_dns_zones ? azurerm_private_dns_zone.created_zones : data.azurerm_private_dns_zone.existing_zones
   name                  = "vnl-${each.value.name}-flwr-${local.naming_suffix}"
-  resource_group_name   = var.private_dns_zones_rg == null ? azurerm_resource_group.core.name : var.private_dns_zones_rg
+  resource_group_name   = local.create_dns_zones ? azurerm_resource_group.core.name : var.private_dns_zones_rg
   private_dns_zone_name = each.value.name
   virtual_network_id    = azurerm_virtual_network.core.id
   tags                  = var.tags
@@ -151,7 +151,7 @@ resource "azurerm_private_endpoint" "blob" {
   private_dns_zone_group {
     name = "private-dns-zone-group-blob-${local.naming_suffix}"
     private_dns_zone_ids = [
-      var.private_dns_zones_rg == null
+      local.create_dns_zones
       ? azurerm_private_dns_zone.created_zones["blob"].id
       : data.azurerm_private_dns_zone.existing_zones["blob"].id
     ]
@@ -183,7 +183,7 @@ resource "azurerm_private_endpoint" "keyvault" {
   private_dns_zone_group {
     name = "private-dns-zone-group-kv-${local.naming_suffix}"
     private_dns_zone_ids = [
-      var.private_dns_zones_rg == null
+      local.create_dns_zones
       ? azurerm_private_dns_zone.created_zones["keyvault"].id
       : data.azurerm_private_dns_zone.existing_zones["keyvault"].id
     ]

--- a/infrastructure/core/outputs.tf
+++ b/infrastructure/core/outputs.tf
@@ -73,5 +73,5 @@ output "storage_account_name" {
 }
 
 output "private_dns_zones" {
-  value = var.private_dns_zones_rg == null ? azurerm_private_dns_zone.created_zones : data.azurerm_private_dns_zone.existing_zones
+  value = local.create_dns_zones ? azurerm_private_dns_zone.created_zones : data.azurerm_private_dns_zone.existing_zones
 }

--- a/infrastructure/serve/terragrunt.hcl
+++ b/infrastructure/serve/terragrunt.hcl
@@ -20,6 +20,8 @@ dependency "core" {
   config_path = "../core"
 
   mock_outputs = {
+    naming_suffix               = "naming_suffix"
+    naming_suffix_truncated     = "naming_suffix_truncated"
     core_rg_name                = "core_rg_name"
     core_rg_location            = "core_rg_location"
     core_kv_id                  = "core_kv_id"
@@ -28,7 +30,7 @@ dependency "core" {
     serve_webapps_address_space = "serve_webapps_address_space"
     private_dns_zones           = "private_dns_zones"
   }
-  mock_outputs_allowed_terraform_commands = ["destroy"]
+  mock_outputs_allowed_terraform_commands = ["init", "destroy"]
 }
 
 inputs = {

--- a/infrastructure/serve/terragrunt.hcl
+++ b/infrastructure/serve/terragrunt.hcl
@@ -29,6 +29,7 @@ dependency "core" {
     core_subnet_id              = "core_subnet_id"
     serve_webapps_address_space = "serve_webapps_address_space"
     private_dns_zones           = "private_dns_zones"
+    deployer_ip                 = "depoyer_ip"
   }
   mock_outputs_allowed_terraform_commands = ["init", "destroy"]
 }

--- a/infrastructure/transform/databricks.tf
+++ b/infrastructure/transform/databricks.tf
@@ -25,7 +25,7 @@ resource "azurerm_databricks_workspace" "databricks" {
 
   custom_parameters {
     no_public_ip                                         = true
-    storage_account_name                                 = local.storage_account_name
+    storage_account_name                                 = local.dbfs_storage_account_name
     public_subnet_name                                   = data.azurerm_subnet.databricks_host.name
     private_subnet_name                                  = data.azurerm_subnet.databricks_container.name
     virtual_network_id                                   = data.azurerm_virtual_network.core.id

--- a/infrastructure/transform/locals.tf
+++ b/infrastructure/transform/locals.tf
@@ -20,6 +20,7 @@ locals {
   trigger_file                       = "trigger.json"
   artifacts_dir                      = "artifacts"
   adb_linked_service_name            = "ADBLinkedServiceViaMSI"
+  dbfs_storage_account_name          = "dbfs${var.naming_suffix_truncated}"
 
   # IPs required for Databricks UDRs 
   # Built from https://learn.microsoft.com/en-us/azure/databricks/resources/supported-regions#--control-plane-nat-webapp-and-extended-infrastructure-ip-addresses-and-domains
@@ -63,8 +64,6 @@ locals {
       } : null
     ]
   ])
-
-  storage_account_name = "dbfs${var.naming_suffix_truncated}"
 
   data_source_connections_with_peerings = [
     for idx, item in var.data_source_connections : item if item.peering != null

--- a/infrastructure/transform/network.tf
+++ b/infrastructure/transform/network.tf
@@ -100,7 +100,7 @@ resource "azurerm_private_endpoint" "databricks_filesystem" {
 
   private_service_connection {
     name                           = "private-service-connection-databricks-filesystem-${var.naming_suffix}"
-    private_connection_resource_id = join("", [azurerm_databricks_workspace.databricks.managed_resource_group_id, "/providers/Microsoft.Storage/storageAccounts/${local.storage_account_name}"])
+    private_connection_resource_id = join("", [azurerm_databricks_workspace.databricks.managed_resource_group_id, "/providers/Microsoft.Storage/storageAccounts/${local.dbfs_storage_account_name}"])
     is_manual_connection           = false
     subresource_names              = ["blob"]
   }
@@ -132,5 +132,5 @@ resource "azurerm_private_dns_zone_virtual_network_link" "data_sources" {
   name                  = "vnl-${each.key}-flwr-${var.naming_suffix}"
   private_dns_zone_name = each.value.dns_zone_name
   virtual_network_id    = data.azurerm_virtual_network.core.id
-  resource_group_name   = each.value.resource_group_name
+  resource_group_name   = var.private_dns_zones_rg == null ? each.value.resource_group_name : var.private_dns_zones_rg
 }

--- a/infrastructure/transform/terragrunt.hcl
+++ b/infrastructure/transform/terragrunt.hcl
@@ -32,8 +32,10 @@ dependency "core" {
     core_subnet_id                     = "core_subnet_id"
     core_kv_id                         = "core_kv_id"
     core_kv_uri                        = "core_kv_uri"
-    databricks_host_address_space      = "databricks_host_address_space"
-    databricks_container_address_space = "databricks_container_address_space"
+    p0_action_group_id                 = "p0_action_group_id"
+    storage_account_name               = "storage_account_name"
+    databricks_host_subnet_name        = "databricks_host_subnet_name"
+    databricks_container_subnet_name   = "databricks_container_subnet_name"
     deployer_ip                        = "deployer_ip"
     private_dns_zones                  = "private_dns_zones"
   }

--- a/infrastructure/transform/terragrunt.hcl
+++ b/infrastructure/transform/terragrunt.hcl
@@ -24,6 +24,8 @@ dependency "core" {
   config_path = "../core"
 
   mock_outputs = {
+    naming_suffix                      = "naming_suffix"
+    naming_suffix_truncated            = "naming_suffix_truncated"
     core_rg_name                       = "core_rg_name"
     core_rg_location                   = "core_rg_location"
     core_vnet_name                     = "core_vnet_name"
@@ -35,7 +37,7 @@ dependency "core" {
     deployer_ip                        = "deployer_ip"
     private_dns_zones                  = "private_dns_zones"
   }
-  mock_outputs_allowed_terraform_commands = ["destroy"]
+  mock_outputs_allowed_terraform_commands = ["init", "destroy"]
 }
 
 generate "terraform" {

--- a/infrastructure/transform/terragrunt.hcl
+++ b/infrastructure/transform/terragrunt.hcl
@@ -20,6 +20,14 @@ locals {
   providers = read_terragrunt_config("${get_repo_root()}/providers.hcl")
 }
 
+terraform {
+  before_hook "before_hook" {
+    commands    = ["apply", "plan"]
+    execute     = ["make", "transform-artifacts"]
+    working_dir = get_repo_root()
+  }
+}
+
 dependency "core" {
   config_path = "../core"
 

--- a/infrastructure/transform/variables.tf
+++ b/infrastructure/transform/variables.tf
@@ -81,6 +81,11 @@ variable "private_dns_zones" {
   type = map(any)
 }
 
+variable "private_dns_zones_rg" {
+  type    = string
+  default = null
+}
+
 variable "access_databricks_management_publicly" {
   type        = bool
   description = "Whether to allow access to the Databricks workspace management plane via a public network"

--- a/infrastructure/transform/variables.tf
+++ b/infrastructure/transform/variables.tf
@@ -114,7 +114,7 @@ variable "data_source_connections" {
       object({
         virtual_network_name = string
         resource_group_name  = string
-        dns_zones            = list(string)
+        dns_zones            = optional(list(string), [])
       })
     )
   }))

--- a/shared.hcl
+++ b/shared.hcl
@@ -17,7 +17,7 @@ locals {
   configuration    = read_terragrunt_config("${get_repo_root()}/configuration.hcl")
   tf_in_automation = get_env("TF_IN_AUTOMATION", false)
   suffix_override  = get_env("SUFFIX_OVERRIDE", "")
-  state_folder     = local.suffix_override != "" ? local.suffix_override : get_env("ENVIRONMENT", "")
+  state_folder     = "flowehr/${local.suffix_override != "" ? local.suffix_override : get_env("ENVIRONMENT", "")}"
 }
 
 generate "terraform" {
@@ -67,7 +67,7 @@ inputs = merge(
 
   # Tags to add to every resource that accepts them
   tags = {
-    environment = local.configuration.locals.merged_root_config.environment
+    environment = try(local.configuration.locals.merged_root_config.environment, "local")
   }
 })
 


### PR DESCRIPTION
- Adds flowehr prefix to tf state
  - To differentiate different projects in the state storage (i.e. FlowEHR, Data sources, TRE ...), this adds a prefix to the remote state block - resolves #251
- `make all` command works without having any apps defined (by making the serve block optional unless an app is present in the apps.yaml)
- `make all` now calls `transform-artifacts` - resolves #249 
- Makes data sources `dns_zones` optional
- If `private_dns_zones_rg` is defined, data source dns zone linking will look in that rg instead for existing zones to link to. Resolves #250

## Before merge

- [ ] Manually move infra-test and app-dev state from `/` to `/flowehr`