### PR TITLE
Fix cleanup step

### DIFF
--- a/.github/workflows/clean_state.yml
+++ b/.github/workflows/clean_state.yml
@@ -53,9 +53,9 @@ jobs:
       - name: Delete TF state
         run: |
           az storage blob delete-batch \
-            --account-name "${{ vars.CI_STORAGE_ACCOUNT }}"
-            -s tfstate
-            --pattern "flowehr/${{ (inputs.suffix_override != '' && inputs.suffix_override) || inputs.environment }}/*"
+            --account-name "${{ vars.CI_STORAGE_ACCOUNT }}" \
+            --source tfstate \
+            --pattern "flowehr/${{ (inputs.suffix_override != '' && inputs.suffix_override) || inputs.environment }}/*" \
             --auth-mode login
       - name: Untag devcontainer image
         run: |

--- a/.github/workflows/clean_state.yml
+++ b/.github/workflows/clean_state.yml
@@ -60,5 +60,5 @@ jobs:
       - name: Untag devcontainer image
         run: |
           az acr repository untag \
-            --name ${{ vars.CI_CONTAINER_REGISTRY }} \
+            --name "${{ vars.CI_CONTAINER_REGISTRY }}" \
             --image "${{ inputs.devcontainer_name }}:${{ (inputs.suffix_override != '' && inputs.suffix_override) || inputs.environment }}"

--- a/.github/workflows/clean_state.yml
+++ b/.github/workflows/clean_state.yml
@@ -52,12 +52,11 @@ jobs:
           creds: '{"clientId":"${{ secrets.ARM_CLIENT_ID }}","clientSecret":"${{ secrets.ARM_CLIENT_SECRET }}","subscriptionId":"${{ secrets.ARM_SUBSCRIPTION_ID }}","tenantId":"${{ secrets.ARM_TENANT_ID }}"}'
       - name: Delete TF state
         run: |
-          az storage fs directory delete \
-            --file-system tfstate \
-            --name ${{ (inputs.suffix_override != '' && inputs.suffix_override) || inputs.environment }} \
-            --account-name ${{ vars.CI_STORAGE_ACCOUNT }} \
-            --auth-mode login \
-            --yes
+          az storage blob delete-batch \
+            --account-name "${{ vars.CI_STORAGE_ACCOUNT }}"
+            -s tfstate
+            --pattern "flowehr/${{ (inputs.suffix_override != '' && inputs.suffix_override) || inputs.environment }}/*"
+            --auth-mode login
       - name: Untag devcontainer image
         run: |
           az acr repository untag \

--- a/.github/workflows/clean_state.yml
+++ b/.github/workflows/clean_state.yml
@@ -61,5 +61,4 @@ jobs:
         run: |
           az acr repository untag \
             --name ${{ vars.CI_CONTAINER_REGISTRY }} \
-            --image ${{ inputs.devcontainer_name }}:${{ (inputs.suffix_override != '' && inputs.suffix_override) || inputs.environment }} \
-            --yes
+            --image ${{ inputs.devcontainer_name }}:${{ (inputs.suffix_override != '' && inputs.suffix_override) || inputs.environment }}

--- a/.github/workflows/clean_state.yml
+++ b/.github/workflows/clean_state.yml
@@ -61,4 +61,4 @@ jobs:
         run: |
           az acr repository untag \
             --name ${{ vars.CI_CONTAINER_REGISTRY }} \
-            --image ${{ inputs.devcontainer_name }}:${{ (inputs.suffix_override != '' && inputs.suffix_override) || inputs.environment }}
+            --image "${{ inputs.devcontainer_name }}:${{ (inputs.suffix_override != '' && inputs.suffix_override) || inputs.environment }}"


### PR DESCRIPTION
# Resolves #245 

## What is being addressed

Clean-up currently fails due to soft-delete being enabled on the storage account and cli `storage fs` commands only working for non-soft-delete accounts. We need to use an alternate method for cleaning state.

## How is this addressed

- Use the `storage blob delete-batch` command which works with soft-delete storage accounts
- Use a pattern for the subfolders to delete
- Removes unnecessary `--yes` flag from acr untag

Tested and successful in my private fork:

<img width="791" alt="image" src="https://user-images.githubusercontent.com/25235950/232626590-5eb53fd3-5f3f-49c3-b537-34c95b6d6818.png">

