### PR TITLE
Fix for AD group names in persistent environments

### DIFF
--- a/infrastructure/core/groups.tf
+++ b/infrastructure/core/groups.tf
@@ -14,14 +14,14 @@
 
 resource "azuread_group" "ad_group_developers" {
   count            = var.accesses_real_data ? 0 : 1
-  display_name     = "${var.suffix_override} flowehr-developers"
+  display_name     = "${local.naming_suffix} flowehr-developers"
   owners           = [data.azurerm_client_config.current.object_id]
   security_enabled = true
 }
 
 resource "azuread_group" "ad_group_data_scientists" {
   count            = var.accesses_real_data ? 0 : 1
-  display_name     = "${var.suffix_override} flowehr-data-scientists"
+  display_name     = "${local.naming_suffix} flowehr-data-scientists"
   owners           = [data.azurerm_client_config.current.object_id]
   security_enabled = true
 }


### PR DESCRIPTION
Data scientists + developers AD groups were named with `suffix_override` which was ok for transient builds but blank in persistent builds. Moves to `naming_suffix` instead.

