### PR TITLE
Add missing Data Factory Trigger TF dependency

### DIFF
--- a/infrastructure/transform/pipeline.tf
+++ b/infrastructure/transform/pipeline.tf
@@ -59,4 +59,8 @@ resource "azurerm_data_factory_trigger_tumbling_window" "pipeline_trigger" {
   }
 
   // Trigger dependencies and additional properties aren't supported
+
+  depends_on = [
+    azurerm_data_factory_pipeline.pipeline
+  ]
 }


### PR DESCRIPTION

## What is being addressed

Trigger resource needs to have dependency on pipeline otherwise it can error our depending on timing.

