### PR TITLE
Add optional runner_label input

### DIFF
--- a/.github/workflows/devcontainer_make_command.yml
+++ b/.github/workflows/devcontainer_make_command.yml
@@ -38,6 +38,10 @@ on:
         required: false
         description: The devcontainer image name
         default: flowehr/devcontainer
+      runner_label:
+        type: string
+        required: false
+        description: A specific GitHub runner label to run this workflow on. Overrides vars.CI_GITHUB_RUNNER_LABEL, which may be set at a repo level
     secrets:
       ARM_SUBSCRIPTION_ID:
         required: true
@@ -55,7 +59,7 @@ on:
 jobs:
   make:
     name: make ${{ inputs.command }}
-    runs-on: [self-hosted, "${{ vars.CI_GITHUB_RUNNER_LABEL }}"]
+    runs-on: [self-hosted, "${{ (inputs.runner_label != '' && inputs.runner_label) || vars.CI_GITHUB_RUNNER_LABEL }}"]
     environment: ${{ inputs.environment }}
     steps:
       - name: Set devcontainer attributes


### PR DESCRIPTION
Adds an optional input to the deploy workflow which can be used to override a repository scoped CI_GITHUB_RUNNER_LABEL. This is required if this workflow is going to be run on different runners within the same repository.  Sadly using a envrionment scoped `vars.CI_GITHUB_RUNNER_LABEL` doesn't work in the runs-on section