### PR TITLE
Add missing actions:read scope to GH App scopes

### DIFF
--- a/apps/README.md
+++ b/apps/README.md
@@ -19,6 +19,7 @@ Once you've done (or not done) that, follow [these instructions](https://docs.gi
 - `Webhook`: uncheck the Active checkbox
 - `Permissions`
     - `Repository Permissions`
+        - `Actions`: `Read-only`
         - `Administration`: `Read and write`
         - `Contents`: `Read and write`
         - `Environments`: `Read and write`


### PR DESCRIPTION
Fix for issue we're facing on private UCLH fork when deploying a private app

Requests to the deployment environments API require `actions: read-only` scopes for GitHub Apps when querying private repos, which is why it's worked for public. The knock-on effect was causing the GitHub TF provider to crash, which is a bad error handling bug that ive raised an issue on the provide for.