### PR TITLE
Fix outputs when no group created

### DIFF
--- a/infrastructure/core/outputs.tf
+++ b/infrastructure/core/outputs.tf
@@ -78,7 +78,7 @@ output "private_dns_zones" {
 
 output "developers_ad_group_principal_id" {
   description = "Developers AD group principal id"
-  value       = azuread_group.ad_group_developers[0].object_id
+  value       = var.accesses_real_data ? "" : azuread_group.ad_group_developers[0].object_id
 }
 
 output "data_scientists_ad_group_principal_id" {
@@ -88,7 +88,7 @@ output "data_scientists_ad_group_principal_id" {
 
 output "developers_ad_group_display_name" {
   description = "Developers AD group display name"
-  value       = azuread_group.ad_group_developers[0].display_name
+  value       = var.accesses_real_data ? "" : azuread_group.ad_group_developers[0].display_name
 }
 
 output "data_scientists_ad_group_display_name" {


### PR DESCRIPTION
Fixes the outputs with `accesses_real_data = true`

Needs to be an empty string not `null` so terragrunt doesn't complain. Have tested locally and works