### PR TITLE
Synth sql access for local devs

### DIFF
--- a/infrastructure/transform/feature-data-store.tf
+++ b/infrastructure/transform/feature-data-store.tf
@@ -41,7 +41,7 @@ resource "azurerm_mssql_server" "sql_server_features" {
   version                              = "12.0"
   administrator_login                  = local.sql_server_features_admin_username
   administrator_login_password         = random_password.sql_admin_password.result
-  public_network_access_enabled        = !var.tf_in_automation
+  public_network_access_enabled        = !var.accesses_real_data
   outbound_network_restriction_enabled = true
   tags                                 = var.tags
   azuread_administrator {


### PR DESCRIPTION
# Resolves #271 

For the feature store sql server, Public networking should only be disabled when `accesses_real_data` is true so that it can be accessed locally for development in `app-dev` and other synthetic environments