### PR TITLE
Fix multiple app config parsing bug (move app config type definition to parent module)

### DIFF
--- a/apps/app/variables.tf
+++ b/apps/app/variables.tf
@@ -100,27 +100,5 @@ variable "data_scientists_ad_group_principal_id" {
 }
 
 variable "app_config" {
-  type = object({
-    name             = string
-    description      = optional(string, "Created by FlowEHR")
-    add_testing_slot = optional(bool, false)
-    require_auth     = optional(bool, true)
-    owners           = map(string)
-    contributors     = map(string)
-
-    managed_repo = optional(object({
-      private  = bool
-      template = string
-    }))
-
-    branch = optional(object({
-      num_of_approvals      = optional(number, 1),
-      dismiss_stale_reviews = optional(bool, false)
-      }), {
-      num_of_approvals      = 1
-      dismiss_stale_reviews = false
-    })
-
-    env = optional(map(string))
-  })
+  type = any // validated by parent
 }

--- a/apps/terragrunt.hcl
+++ b/apps/terragrunt.hcl
@@ -26,8 +26,8 @@ locals {
   # Get shared app configuration (apps.yaml) and environment-specific config (app.{ENVIRONMENT}.yaml)
   shared_apps_config_path = "${get_terragrunt_dir()}/apps.yaml"
   env_apps_config_path    = "${get_terragrunt_dir()}/apps.${get_env("ENVIRONMENT", "local")}.yaml"
-  shared_apps_config      = fileexists(local.shared_apps_config_path) ? yamldecode(file(local.shared_apps_config_path)) : tomap({})
-  env_apps_config         = fileexists(local.env_apps_config_path) ? yamldecode(file(local.env_apps_config_path)) : tomap({})
+  shared_apps_config      = fileexists(local.shared_apps_config_path) ? tomap(yamldecode(file(local.shared_apps_config_path))) : tomap({})
+  env_apps_config         = fileexists(local.env_apps_config_path) ? tomap(yamldecode(file(local.env_apps_config_path))) : tomap({})
 
   merged_apps_config = {
     # As it's a map, we need to iterate as direct merge() would overwrite each key's value entirely

--- a/apps/variables.tf
+++ b/apps/variables.tf
@@ -105,5 +105,27 @@ variable "serve" {
 
 variable "apps" {
   description = "Apps configuration file containing the apps to deploy"
-  type        = map(any) # App config is validated within ./app module
+  type = map(object({
+    name             = string
+    description      = optional(string, "Created by FlowEHR")
+    add_testing_slot = optional(bool, false)
+    require_auth     = optional(bool, true)
+    owners           = map(string)
+    contributors     = map(string)
+
+    managed_repo = optional(object({
+      private  = bool
+      template = string
+    }))
+
+    branch = optional(object({
+      num_of_approvals      = optional(number, 1),
+      dismiss_stale_reviews = optional(bool, false)
+      }), {
+      num_of_approvals      = 1
+      dismiss_stale_reviews = false
+    })
+
+    env = optional(map(string))
+  }))
 }


### PR DESCRIPTION
# Fixes #277

## What is being addressed

Fixes a bug where more than one app being defined causes terraform to fail parsing into a map.

## How is this addressed

- Moves the object type definition into the parent variables.tf which allows Terraform to convert the object into a map of objects correctly

