### PR TITLE
Only look up contributor ad ids if needed

### DIFF
--- a/apps/app/data.tf
+++ b/apps/app/data.tf
@@ -42,7 +42,7 @@ data "azurerm_mssql_server" "feature_store" {
 }
 
 data "azuread_user" "contributors_ids" {
-  for_each            = var.app_config.contributors
+  for_each            = !var.accesses_real_data ? var.app_config.contributors : toset([])
   user_principal_name = each.value
 }
 

--- a/apps/app/data.tf
+++ b/apps/app/data.tf
@@ -42,7 +42,7 @@ data "azurerm_mssql_server" "feature_store" {
 }
 
 data "azuread_user" "contributors_ids" {
-  for_each            = !var.accesses_real_data ? var.app_config.contributors : toset([])
+  for_each            = !var.accesses_real_data ? var.app_config.contributors : tomap({})
   user_principal_name = each.value
 }
 

--- a/apps/app/webapp.tf
+++ b/apps/app/webapp.tf
@@ -202,17 +202,19 @@ resource "azuread_group_member" "webapp" {
 }
 
 resource "azuread_group" "developers_of_this_app" {
+  count            = !var.accesses_real_data ? 1 : 0
   display_name     = "${var.app_id} app developers"
   security_enabled = true
 }
 
 resource "azuread_group_member" "add_each_developer_to_group" {
-  for_each         = data.azuread_user.contributors_ids
-  group_object_id  = azuread_group.developers_of_this_app.id
+  for_each         = !var.accesses_real_data ? data.azuread_user.contributors_ids : toset([])
+  group_object_id  = azuread_group.developers_of_this_app[0].id
   member_object_id = each.value.object_id
 }
 
 resource "azuread_group_member" "developers" {
+  count            = !var.accesses_real_data ? 1 : 0
   group_object_id  = var.developers_ad_group_principal_id
-  member_object_id = azuread_group.developers_of_this_app.id
+  member_object_id = azuread_group.developers_of_this_app[0].id
 }

--- a/apps/app/webapp.tf
+++ b/apps/app/webapp.tf
@@ -208,7 +208,7 @@ resource "azuread_group" "developers_of_this_app" {
 }
 
 resource "azuread_group_member" "add_each_developer_to_group" {
-  for_each         = !var.accesses_real_data ? data.azuread_user.contributors_ids : toset([])
+  for_each         = !var.accesses_real_data ? data.azuread_user.contributors_ids : tomap({})
   group_object_id  = azuread_group.developers_of_this_app[0].id
   member_object_id = each.value.object_id
 }

--- a/infrastructure/serve/.terraform.lock.hcl
+++ b/infrastructure/serve/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/azure/azapi" {
   constraints = "1.5.0"
   hashes = [
     "h1:wiX+oIlwttTKq6z3LGbrqmRCkN66C0YgqxM+jKQbejw=",
+    "h1:y8+jCfTmrUzyAYiy19v8OJMD8tXKiTCQY7lHml8clgE=",
     "zh:14109c169973e1b0d526131ca047e25f62700a44ecce4303aacb15793764be3e",
     "zh:19417f2bbbadd0a079d51646a929d43ae7a0293f0fc13c3fa369d32780c1c846",
     "zh:3254370d3304227ea0ec1352d98aa4a4a59e6a76ddede26454bdb55048101ec3",
@@ -47,6 +48,7 @@ provider "registry.terraform.io/hashicorp/external" {
   constraints = "2.3.1"
   hashes = [
     "h1:bROCw6g5D/3fFnWeJ01L4IrdnJl1ILU8DGDgXCtYzaY=",
+    "h1:uf2KGH9D2vAdfnj8ZAqEwVIpxI82WHsanraXn3dOHzA=",
     "zh:001e2886dc81fc98cf17cf34c0d53cb2dae1e869464792576e11b0f34ee92f54",
     "zh:2eeac58dd75b1abdf91945ac4284c9ccb2bfb17fa9bdb5f5d408148ff553b3ee",
     "zh:2fc39079ba61411a737df2908942e6970cb67ed2f4fb19090cd44ce2082903dd",
@@ -66,6 +68,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version     = "2.4.0"
   constraints = "2.4.0"
   hashes = [
+    "h1:OMqURhlP2IgLEgUCzSlaKXyb/IbnKForgDSjZF/NY4Y=",
     "h1:R97FTYETo88sT2VHfMgkPU3lzCsZLunPftjSI5vfKe8=",
     "zh:53604cd29cb92538668fe09565c739358dc53ca56f9f11312b9d7de81e48fab9",
     "zh:66a46e9c508716a1c98efbf793092f03d50049fa4a83cd6b2251e9a06aca2acf",
@@ -87,6 +90,7 @@ provider "registry.terraform.io/hashicorp/null" {
   constraints = "3.2.1"
   hashes = [
     "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
+    "h1:wqgRvlyVIbkCeCQs+5jj6zVuQL0KDxZZtNofGqqlSdI=",
     "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
     "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
     "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
@@ -107,6 +111,7 @@ provider "registry.terraform.io/hashicorp/time" {
   constraints = "0.9.1"
   hashes = [
     "h1:NUv/YtEytDQncBQ2mTxnUZEy/rmDlPYmE9h2iokR0vk=",
+    "h1:ZrIFtdifvwIr1JocYT311cvOgIUdislZuZ2MzZmxQQ0=",
     "zh:00a1476ecf18c735cc08e27bfa835c33f8ac8fa6fa746b01cd3bcbad8ca84f7f",
     "zh:3007f8fc4a4f8614c43e8ef1d4b0c773a5de1dcac50e701d8abc9fdc8fcb6bf5",
     "zh:5f79d0730fdec8cb148b277de3f00485eff3e9cf1ff47fb715b1c969e5bbd9d4",


### PR DESCRIPTION
# Resolves #290

## What is being addressed

This fixes an issue where TF is trying to look up app contributor users in AD when `var.accesses_real_data` is true, when it doesn't need to (as we don't add anyone to a group to access data locally when the data is real. They may not exist in a prod tenant thus this can break deployments (and has).
