### PR TITLE
Allow apps to read model registry

### DIFF
--- a/infrastructure/core/groups.tf
+++ b/infrastructure/core/groups.tf
@@ -30,3 +30,9 @@ resource "azuread_group" "ad_group_algorithm_stewards" {
   owners           = [data.azurerm_client_config.current.object_id]
   security_enabled = true
 }
+
+resource "azuread_group" "ad_group_apps" {
+  display_name     = "${local.naming_suffix} flowehr-apps"
+  owners           = [data.azurerm_client_config.current.object_id]
+  security_enabled = true
+}

--- a/infrastructure/core/outputs.tf
+++ b/infrastructure/core/outputs.tf
@@ -86,6 +86,16 @@ output "data_scientists_ad_group_principal_id" {
   value       = azuread_group.ad_group_data_scientists.object_id
 }
 
+output "apps_ad_group_principal_id" {
+  description = "Apps AD group principal id"
+  value       = azuread_group.ad_group_apps.object_id
+}
+
+output "apps_ad_group_display_name" {
+  description = "Apps AD group display name"
+  value       = azuread_group.ad_group_apps.display_name
+}
+
 output "developers_ad_group_display_name" {
   description = "Developers AD group display name"
   value       = var.accesses_real_data ? "" : azuread_group.ad_group_developers[0].display_name

--- a/infrastructure/serve/aml.tf
+++ b/infrastructure/serve/aml.tf
@@ -64,8 +64,35 @@ resource "azurerm_role_definition" "aml_registry_read_write" {
   ]
 }
 
+resource "azurerm_role_definition" "aml_registry_read_only" {
+  name        = "role-aml-registry-read-${var.naming_suffix}"
+  scope       = local.aml_registry_id
+  description = "Read from an AML model registry"
+
+  permissions {
+    actions = [
+      "Microsoft.MachineLearningServices/registries/read",
+      "Microsoft.MachineLearningServices/registries/assets/read"
+    ]
+  }
+
+  assignable_scopes = [
+    local.aml_registry_id
+  ]
+
+  depends_on = [
+    null_resource.az_cli_registry_create
+  ]
+}
+
 resource "azurerm_role_assignment" "algorithm_stewards_can_use_registry" {
   scope              = local.aml_registry_id
   role_definition_id = replace(azurerm_role_definition.aml_registry_read_write.id, "|", "")
   principal_id       = var.algorithm_stewards_ad_group_principal_id
+}
+
+resource "azurerm_role_assignment" "apps_can_read_registry" {
+  scope              = local.aml_registry_id
+  role_definition_id = replace(azurerm_role_definition.aml_registry_read_only.id, "|", "")
+  principal_id       = var.apps_ad_group_principal_id
 }

--- a/infrastructure/serve/terragrunt.hcl
+++ b/infrastructure/serve/terragrunt.hcl
@@ -53,6 +53,7 @@ dependency "core" {
     aml_address_space           = "aml_address_space"
 
     algorithm_stewards_ad_group_principal_id = "algorithm_stewards_ad_group_principal_id"
+    apps_ad_group_principal_id               = "apps_ad_group_principal_id"
   }
   mock_outputs_allowed_terraform_commands = ["init", "destroy", "validate"]
 }

--- a/infrastructure/serve/terragrunt.hcl
+++ b/infrastructure/serve/terragrunt.hcl
@@ -65,4 +65,5 @@ inputs = {
   core_subnet_id                           = dependency.core.outputs.core_subnet_id
   private_dns_zones                        = dependency.core.outputs.private_dns_zones
   algorithm_stewards_ad_group_principal_id = dependency.core.outputs.algorithm_stewards_ad_group_principal_id
+  apps_ad_group_principal_id               = dependency.core.outputs.apps_ad_group_principal_id
 }

--- a/infrastructure/serve/variables.tf
+++ b/infrastructure/serve/variables.tf
@@ -48,3 +48,7 @@ variable "private_dns_zones" {
 variable "algorithm_stewards_ad_group_principal_id" {
   type = string
 }
+
+variable "apps_ad_group_principal_id" {
+  type = string
+}

--- a/infrastructure/transform/feature-data-store.tf
+++ b/infrastructure/transform/feature-data-store.tf
@@ -209,12 +209,6 @@ resource "azurerm_private_endpoint" "sql_server_features_pe" {
   }
 }
 
-resource "azuread_group" "ad_group_apps" {
-  display_name     = "${var.naming_suffix} flowehr-apps"
-  owners           = [data.azurerm_client_config.current.object_id]
-  security_enabled = true
-}
-
 resource "azurerm_monitor_activity_log_alert" "feature_database_firewall_update" {
   name                = "activity-log-alert-sql-fw-${var.naming_suffix}"
   resource_group_name = var.core_rg_name

--- a/infrastructure/transform/locals.tf
+++ b/infrastructure/transform/locals.tf
@@ -96,14 +96,14 @@ locals {
   databricks_app  = { "name" : local.databricks_app_name, "role" : "db_owner" }
 
   real_data_users_groups = [
-    local.data_scientists,
     local.apps,
+    local.data_scientists,
     local.databricks_app
   ]
 
   synth_data_users_groups = [
-    local.data_scientists,
     local.apps,
+    local.data_scientists,
     local.databricks_app,
     local.developers
   ]

--- a/infrastructure/transform/locals.tf
+++ b/infrastructure/transform/locals.tf
@@ -92,7 +92,7 @@ locals {
 
   developers      = { "name" : var.developers_ad_group_display_name, "role" : "db_datareader" }
   data_scientists = { "name" : var.data_scientists_ad_group_display_name, "role" : "db_datareader" }
-  apps            = { "name" : azuread_group.ad_group_apps.display_name, "role" : "db_datareader" }
+  apps            = { "name" : var.apps_ad_group_display_name, "role" : "db_datareader" }
   databricks_app  = { "name" : local.databricks_app_name, "role" : "db_owner" }
 
   real_data_users_groups = [

--- a/infrastructure/transform/outputs.tf
+++ b/infrastructure/transform/outputs.tf
@@ -20,11 +20,6 @@ output "feature_store_db_name" {
   value = azurerm_mssql_database.feature_database.name
 }
 
-output "apps_ad_group_principal_id" {
-  description = "Apps AD group principal id"
-  value       = azuread_group.ad_group_apps.object_id
-}
-
 output "adf_name" {
   value = azurerm_data_factory.adf.name
 }

--- a/infrastructure/transform/terragrunt.hcl
+++ b/infrastructure/transform/terragrunt.hcl
@@ -105,4 +105,5 @@ inputs = {
   data_scientists_ad_group_principal_id = dependency.core.outputs.data_scientists_ad_group_principal_id
   developers_ad_group_display_name      = dependency.core.outputs.developers_ad_group_display_name
   data_scientists_ad_group_display_name = dependency.core.outputs.data_scientists_ad_group_display_name
+  apps_ad_group_display_name            = dependency.core.outputs.apps_ad_group_display_name
 }

--- a/infrastructure/transform/terragrunt.hcl
+++ b/infrastructure/transform/terragrunt.hcl
@@ -50,6 +50,7 @@ dependency "core" {
     data_scientists_ad_group_principal_id = "data_scientists_ad_group_principal_id"
     developers_ad_group_display_name      = "developers_ad_group_display_name"
     data_scientists_ad_group_display_name = "data_scientists_ad_group_display_name"
+    apps_ad_group_display_name            = "apps_ad_group_display_name"
   }
   mock_outputs_allowed_terraform_commands = ["init", "destroy", "validate"]
 }

--- a/infrastructure/transform/variables.tf
+++ b/infrastructure/transform/variables.tf
@@ -82,6 +82,10 @@ variable "private_dns_zones_rg" {
   default = null
 }
 
+variable "apps_ad_group_display_name" {
+  type = string
+}
+
 variable "developers_ad_group_display_name" {
   type = string
 }


### PR DESCRIPTION
Apps can read the feature store, but they also need to be able to pull from the model registry. This adds a read-only role definition, and grants apps access to it.