### PR TITLE
Store App Secrets in Isolated KV for cross-app auth

### DIFF
--- a/apps/.terraform.lock.hcl
+++ b/apps/.terraform.lock.hcl
@@ -2,8 +2,7 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/azuread" {
-  version     = "2.35.0"
-  constraints = "2.35.0"
+  version = "2.35.0"
   hashes = [
     "h1:TpsHp9ELX3y2RV4EvyM/nuH48jMydEPMFNWhU+WLzMg=",
     "h1:yxuDZvYzlE8j+O57ZwRBTVnQQVKY31Ov266wTSvPxDA=",
@@ -64,30 +63,8 @@ provider "registry.terraform.io/hashicorp/external" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/null" {
-  version     = "3.2.1"
-  constraints = "3.2.1"
-  hashes = [
-    "h1:FbGfc+muBsC17Ohy5g806iuI1hQc4SIexpYCrQHQd8w=",
-    "h1:wqgRvlyVIbkCeCQs+5jj6zVuQL0KDxZZtNofGqqlSdI=",
-    "zh:58ed64389620cc7b82f01332e27723856422820cfd302e304b5f6c3436fb9840",
-    "zh:62a5cc82c3b2ddef7ef3a6f2fedb7b9b3deff4ab7b414938b08e51d6e8be87cb",
-    "zh:63cff4de03af983175a7e37e52d4bd89d990be256b16b5c7f919aff5ad485aa5",
-    "zh:74cb22c6700e48486b7cabefa10b33b801dfcab56f1a6ac9b6624531f3d36ea3",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:79e553aff77f1cfa9012a2218b8238dd672ea5e1b2924775ac9ac24d2a75c238",
-    "zh:a1e06ddda0b5ac48f7e7c7d59e1ab5a4073bbcf876c73c0299e4610ed53859dc",
-    "zh:c37a97090f1a82222925d45d84483b2aa702ef7ab66532af6cbcfb567818b970",
-    "zh:e4453fbebf90c53ca3323a92e7ca0f9961427d2f0ce0d2b65523cc04d5d999c2",
-    "zh:e80a746921946d8b6761e77305b752ad188da60688cfd2059322875d363be5f5",
-    "zh:fbdb892d9822ed0e4cb60f2fedbdbb556e4da0d88d3b942ae963ed6ff091e48f",
-    "zh:fca01a623d90d0cad0843102f9b8b9fe0d3ff8244593bd817f126582b52dd694",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/random" {
-  version     = "3.4.3"
-  constraints = "3.4.3"
+  version = "3.4.3"
   hashes = [
     "h1:hV66lcagXXRwwCW3Y542bI1JgPo8z/taYKT7K+a2Z5U=",
     "h1:xZGZf18JjMS06pFa4NErzANI98qi59SEcBsOcS2P2yQ=",

--- a/apps/app/aad_app/.terraform.lock.hcl
+++ b/apps/app/aad_app/.terraform.lock.hcl
@@ -1,0 +1,59 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azuread" {
+  version = "2.38.0"
+  hashes = [
+    "h1:QN4RAXxh7loMyTD+h+rJW2Nlt8FhMGd1HrwgErZO/uo=",
+    "zh:0a26f1e5409aa93a6bb85dc1b6f2e95376fa6028e4d7dc6938674505e67c83ac",
+    "zh:19bafb7ccbe72fd64b2dccaa79fcb604ca9060afecca7b08f3871796d04c79e0",
+    "zh:1c3e89cf19118fc07d7b04257251fc9897e722c16e0a0df7b07fcd261f8c12e7",
+    "zh:4f2610859eba77117992ceb83d7129056d5b467da970214a8bc9630e84c0fa47",
+    "zh:6460c282713e29021984d3e2ca87cd304bfb426c4b663fea20753e52e2ef6186",
+    "zh:65e05eede2e33c0cd99e0377bb05de29075144f78b94e897eb659563d5983be1",
+    "zh:93a7f376a3f5ee07d8b4e635b5e4b4c1077681d742cb898a3c64d1da95d31357",
+    "zh:ab8537cdd23db2686e9ff41b8698d9fdefa67bcd3451a5a838f21f85a9573cac",
+    "zh:c2f1241e93e9ed43e42bd04a094ea57c369101a6ad178a3c1dee676a2ceb7fb9",
+    "zh:c3e9cac2e8bfa024e05a2ad4ad7249ac8800fa78511838b5046ab30e9912ca2f",
+    "zh:df01da0a5278b42f7be4af686cc2703f77aa55091217ad50ce7913012915cebe",
+    "zh:f6449618a6bbcd625c9acdcad27013f96a5b817fb4d216e4acab52199e1c7437",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version = "3.54.0"
+  hashes = [
+    "h1:56VLqEh+sGU/PLO72UDPKOke3whNNjm4snQQwMzne28=",
+    "zh:0b5c5ffecc73c0f24f6c06c73883153affcb69a0a05376c4a34d71566be7c1e0",
+    "zh:0fb685212f914856c01b7182e2669b9b6d7a3cb77578e2d789baaab3e58fc63e",
+    "zh:3d938b865b36f4821a97e70dbbf8a22f498fb4e9848012c62e8ff2c1461d0760",
+    "zh:42d506add9bba2e96780c0b406f2d6020cf042ffae96faf96988a959766b3644",
+    "zh:433b105444462528f3b3e8619a2edbef6dbd5ce0c694f37ab86d91540c1e427a",
+    "zh:66c3cffd8b01413914703b1728d378e6d37d3b929e84c2a875ad125b828ce1d4",
+    "zh:7cb7187bfcca6f2d4e9d32544b2ca678b65c7c9f520b402d04301152be0c0aa3",
+    "zh:accf83e742d7edfe920b62523a190180257cd59180d0ec0435bf09b74a18e0ae",
+    "zh:c07b4d169931852007b2ba0ad6aaa24e10e9e3b17731080002ef927fb9912483",
+    "zh:e43d945e51228dfb0e1032590fb9409b2b89c40ec8a29cfd2efbd51c536a75a4",
+    "zh:ee248b8cf65fa9d3e8d3859cfcdc6940de5806bdc181b1a794085de162cceb7e",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.5.1"
+  hashes = [
+    "h1:VSnd9ZIPyfKHOObuQCaKfnjIHRtR7qTw19Rz8tJxm+k=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/apps/app/aad_app/data.tf
+++ b/apps/app/aad_app/data.tf
@@ -12,22 +12,6 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-output "cosmos_account_name" {
-  value = azurerm_cosmosdb_account.serve.name
-}
+data "azuread_application_published_app_ids" "well_known" {}
 
-output "app_service_plan_name" {
-  value = azurerm_service_plan.serve.name
-}
-
-output "acr_name" {
-  value = azurerm_container_registry.serve.name
-}
-
-output "serve_key_vault_uri" {
-  value = azurerm_key_vault.serve.vault_uri
-}
-
-output "serve_key_vault_id" {
-  value = azurerm_key_vault.serve.id
-}
+data "azurerm_client_config" "current" {}

--- a/apps/app/aad_app/main.tf
+++ b/apps/app/aad_app/main.tf
@@ -1,0 +1,74 @@
+#  Copyright (c) University College London Hospitals NHS Foundation Trust
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+resource "random_uuid" "webapp_oauth2_id" {}
+
+resource "azuread_service_principal" "msgraph" {
+  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+  use_existing   = true
+}
+
+resource "azuread_application" "webapp_auth" {
+  display_name    = "flowehr-${var.auth_webapp_name}"
+  owners          = [data.azurerm_client_config.current.object_id]
+  identifier_uris = ["api://${var.auth_webapp_name}"]
+
+  required_resource_access {
+    resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
+
+    resource_access {
+      id   = azuread_service_principal.msgraph.oauth2_permission_scope_ids["User.Read"]
+      type = "Scope"
+    }
+  }
+
+  api {
+    oauth2_permission_scope {
+      admin_consent_description  = "Allow the application to access ${var.auth_webapp_name} on behalf of the signed-in user."
+      admin_consent_display_name = "Access ${var.auth_webapp_name}"
+      enabled                    = true
+      id                         = random_uuid.webapp_oauth2_id.result
+      type                       = "User"
+      user_consent_description   = "Allow the application to access ${var.auth_webapp_name} on your behalf."
+      user_consent_display_name  = "Access ${var.auth_webapp_name}"
+      value                      = "user_impersonation"
+    }
+  }
+
+  web {
+    homepage_url  = "https://${var.auth_webapp_name}.azurewebsites.net"
+    redirect_uris = ["https://${var.auth_webapp_name}.azurewebsites.net/.auth/login/aad/callback"]
+
+    implicit_grant {
+      id_token_issuance_enabled = true
+    }
+  }
+}
+
+resource "azuread_application_password" "webapp_auth" {
+  application_object_id = azuread_application.webapp_auth.object_id
+}
+
+# store client ID and secret in serve key vault for cross-app authentication
+resource "azurerm_key_vault_secret" "client_id" {
+  name         = "${var.auth_webapp_name}-client-id"
+  value        = azuread_application.webapp_auth.application_id
+  key_vault_id = var.serve_key_vault_id
+}
+
+resource "azurerm_key_vault_secret" "client_secret" {
+  name         = "${var.auth_webapp_name}-client-secret"
+  value        = azuread_application_password.webapp_auth.value
+  key_vault_id = var.serve_key_vault_id
+}

--- a/apps/app/aad_app/variables.tf
+++ b/apps/app/aad_app/variables.tf
@@ -12,22 +12,10 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-output "cosmos_account_name" {
-  value = azurerm_cosmosdb_account.serve.name
+variable "auth_webapp_name" {
+  type = string
 }
 
-output "app_service_plan_name" {
-  value = azurerm_service_plan.serve.name
-}
-
-output "acr_name" {
-  value = azurerm_container_registry.serve.name
-}
-
-output "serve_key_vault_uri" {
-  value = azurerm_key_vault.serve.vault_uri
-}
-
-output "serve_key_vault_id" {
-  value = azurerm_key_vault.serve.id
+variable "serve_key_vault_id" {
+  type = string
 }

--- a/apps/app/auth.tf
+++ b/apps/app/auth.tf
@@ -12,54 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-resource "azuread_service_principal" "msgraph" {
-  application_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
-  use_existing   = true
-}
-
-resource "random_uuid" "webapp_oauth2_id" {
-  for_each = local.auth_webapp_names
-}
-
-resource "azuread_application" "webapp_auth" {
-  for_each        = local.auth_webapp_names
-  display_name    = "flowehr-${each.value}"
-  owners          = [data.azurerm_client_config.current.object_id]
-  identifier_uris = ["api://${each.value}"]
-
-  required_resource_access {
-    resource_app_id = data.azuread_application_published_app_ids.well_known.result.MicrosoftGraph
-
-    resource_access {
-      id   = azuread_service_principal.msgraph.oauth2_permission_scope_ids["User.Read"]
-      type = "Scope"
-    }
-  }
-
-  api {
-    oauth2_permission_scope {
-      admin_consent_description  = "Allow the application to access ${each.value} on behalf of the signed-in user."
-      admin_consent_display_name = "Access ${each.value}"
-      enabled                    = true
-      id                         = random_uuid.webapp_oauth2_id[each.value].result
-      type                       = "User"
-      user_consent_description   = "Allow the application to access ${each.value} on your behalf."
-      user_consent_display_name  = "Access ${each.value}"
-      value                      = "user_impersonation"
-    }
-  }
-
-  web {
-    homepage_url  = "https://${each.value}.azurewebsites.net"
-    redirect_uris = ["https://${each.value}.azurewebsites.net/.auth/login/aad/callback"]
-
-    implicit_grant {
-      id_token_issuance_enabled = true
-    }
-  }
-}
-
-resource "azuread_application_password" "webapp_auth" {
-  for_each              = local.auth_webapp_names
-  application_object_id = azuread_application.webapp_auth[each.value].object_id
+module "aad_app" {
+  for_each           = local.auth_webapp_names
+  source             = "./aad_app"
+  auth_webapp_name   = each.value
+  serve_key_vault_id = var.serve_key_vault_id
 }

--- a/apps/app/data.tf
+++ b/apps/app/data.tf
@@ -14,8 +14,6 @@
 
 data "azurerm_client_config" "current" {}
 
-data "azuread_application_published_app_ids" "well_known" {}
-
 data "azurerm_log_analytics_workspace" "core" {
   name                = var.log_analytics_name
   resource_group_name = var.resource_group_name

--- a/apps/app/variables.tf
+++ b/apps/app/variables.tf
@@ -78,6 +78,14 @@ variable "feature_store_server_name" {
   type = string
 }
 
+variable "serve_key_vault_uri" {
+  type = string
+}
+
+variable "serve_key_vault_id" {
+  type = string
+}
+
 variable "github_owner" {
   type = string
 }

--- a/apps/app/webapp.tf
+++ b/apps/app/webapp.tf
@@ -108,6 +108,9 @@ resource "azurerm_linux_web_app_slot" "testing" {
     COSMOS_STATE_STORE_ENDPOINT                = data.azurerm_cosmosdb_account.state_store.endpoint
     FEATURE_STORE_CONNECTION_STRING            = local.feature_store_odbc
     ENVIRONMENT                                = local.testing_gh_env
+    TENANT_ID                                  = data.azurerm_client_config.current.tenant_id
+    SUBSCRIPTION_ID                            = data.azurerm_client_config.current.subscription_id
+    KEY_VAULT_URI                              = var.serve_key_vault_uri
   })
 
   identity {

--- a/apps/main.tf
+++ b/apps/main.tf
@@ -48,4 +48,6 @@ module "app" {
   github_owner                          = var.serve.github_owner
   github_access_token                   = data.external.github_access_token[0].result.token
   data_scientists_ad_group_principal_id = var.core_data_scientists_ad_group_principal_id
+  serve_key_vault_id                    = var.serve_key_vault_id
+  serve_key_vault_uri                   = var.serve_key_vault_uri
 }

--- a/apps/terragrunt.hcl
+++ b/apps/terragrunt.hcl
@@ -127,6 +127,8 @@ dependency "serve" {
     app_service_plan_name = "serve_app_service_plan_name"
     acr_name              = "serve_acr_name"
     cosmos_account_name   = "serve_cosmos_account_name"
+    serve_key_vault_uri   = "serve_key_vault_uri"
+    serve_key_vault_id    = "serve_key_vault_id"
   }
   mock_outputs_allowed_terraform_commands = ["init", "destroy", "validate"]
 }
@@ -149,6 +151,8 @@ inputs = {
   serve_app_service_plan_name = dependency.serve.outputs.app_service_plan_name
   serve_acr_name              = dependency.serve.outputs.acr_name
   serve_cosmos_account_name   = dependency.serve.outputs.cosmos_account_name
+  serve_key_vault_uri         = dependency.serve.outputs.serve_key_vault_uri
+  serve_key_vault_id          = dependency.serve.outputs.serve_key_vault_id
 
   github_app_cert = local.github_app_cert
   apps            = local.merged_apps_config

--- a/apps/variables.tf
+++ b/apps/variables.tf
@@ -76,6 +76,14 @@ variable "serve_webapps_subnet_id" {
   type = string
 }
 
+variable "serve_key_vault_uri" {
+  type = string
+}
+
+variable "serve_key_vault_id" {
+  type = string
+}
+
 variable "github_app_cert" {
   description = "GitHub App Private Key PEM file contents as string"
   type        = string

--- a/infrastructure/serve/keyvault.tf
+++ b/infrastructure/serve/keyvault.tf
@@ -1,0 +1,63 @@
+#  Copyright (c) University College London Hospitals NHS Foundation Trust
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+resource "azurerm_key_vault" "serve" {
+  name                          = "kv-${var.naming_suffix_truncated}-serve"
+  location                      = var.core_rg_location
+  resource_group_name           = var.core_rg_name
+  tenant_id                     = data.azurerm_client_config.current.tenant_id
+  enabled_for_disk_encryption   = false
+  public_network_access_enabled = !var.accesses_real_data
+  soft_delete_retention_days    = 7
+  purge_protection_enabled      = var.accesses_real_data
+  enable_rbac_authorization     = true
+  sku_name                      = "standard"
+  tags                          = var.tags
+}
+
+resource "azurerm_role_assignment" "deployer_can_administrate_kv" {
+  scope                = azurerm_key_vault.serve.id
+  role_definition_name = "Key Vault Administrator"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+resource "azurerm_role_assignment" "apps_can_read_secrets" {
+  scope                = azurerm_key_vault.serve.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = var.apps_ad_group_principal_id
+}
+
+resource "azurerm_private_endpoint" "keyvault" {
+  name                = "pe-kv-${var.naming_suffix}-serve"
+  location            = var.core_rg_location
+  resource_group_name = var.core_rg_name
+  subnet_id           = var.core_subnet_id
+  tags                = var.tags
+
+  private_dns_zone_group {
+    name                 = "private-dns-zone-group-kv-${var.naming_suffix}"
+    private_dns_zone_ids = [var.private_dns_zones["keyvault"].id]
+  }
+
+  private_service_connection {
+    name                           = "private-service-connection-kv-${var.naming_suffix}-serve"
+    is_manual_connection           = false
+    private_connection_resource_id = azurerm_key_vault.serve.id
+    subresource_names              = ["Vault"]
+  }
+
+  depends_on = [
+    azurerm_role_assignment.deployer_can_administrate_kv
+  ]
+}


### PR DESCRIPTION
In order for apps to call each other - such as a dashboard to call a model endpoint, they need access to a client id + secret for the calling app. This PR adds a key vault specifically for apps to use. Apps are added as readers so will authenticate to KV using MSI, get the client id + secret for the endpoint, use that to get a token, then call the endpoint.