### PR TITLE
Fix bug: two service principals with the same name

### DIFF
--- a/apps/variables.tf
+++ b/apps/variables.tf
@@ -105,9 +105,9 @@ variable "serve" {
   })
   # Set a default so a serve block isn't required when running make all without any apps configured
   default = {
-    github_owner               = null
-    github_app_id              = null
-    github_app_installation_id = null
+    github_owner               = ""
+    github_app_id              = ""
+    github_app_installation_id = ""
   }
 }
 

--- a/infrastructure/transform/databricks.tf
+++ b/infrastructure/transform/databricks.tf
@@ -50,7 +50,10 @@ resource "time_sleep" "wait_for_databricks_network" {
 
 data "databricks_spark_version" "latest" {
   spark_version = var.transform.spark_version
-  depends_on    = [time_sleep.wait_for_databricks_network]
+  depends_on = [
+    time_sleep.wait_for_databricks_network,
+    azurerm_databricks_workspace.databricks
+  ]
 }
 
 data "databricks_node_type" "smallest" {

--- a/infrastructure/transform/datalake/connections.tf
+++ b/infrastructure/transform/datalake/connections.tf
@@ -29,7 +29,7 @@ resource "azurerm_role_assignment" "adls_adf_contributor" {
 
 # Connect from Databricks using AAD App + SPN
 resource "azuread_application" "databricks_adls" {
-  display_name = var.databricks_app_name
+  display_name = var.databricks_adls_app_name
   owners       = [data.azurerm_client_config.current.object_id]
 }
 

--- a/infrastructure/transform/datalake/variables.tf
+++ b/infrastructure/transform/datalake/variables.tf
@@ -57,7 +57,7 @@ variable "adf_identity_object_id" {
   type = string
 }
 
-variable "databricks_app_name" {
+variable "databricks_adls_app_name" {
   type = string
 }
 

--- a/infrastructure/transform/feature-data-store.tf
+++ b/infrastructure/transform/feature-data-store.tf
@@ -147,7 +147,7 @@ resource "null_resource" "create_sql_user" {
 
 # AAD App + SPN for Databricks -> SQL Access
 resource "azuread_application" "flowehr_databricks_sql" {
-  display_name = local.databricks_app_name
+  display_name = local.databricks_sql_app_name
   owners       = [data.azurerm_client_config.current.object_id]
 }
 resource "azuread_application_password" "flowehr_databricks_sql" {

--- a/infrastructure/transform/feature-data-store.tf
+++ b/infrastructure/transform/feature-data-store.tf
@@ -128,6 +128,7 @@ resource "null_resource" "create_sql_user" {
   # load a csv file into a new SQL table
   provisioner "local-exec" {
     command = <<EOF
+      set -o errexit
       SCRIPTS_DIR="../../scripts"
       $SCRIPTS_DIR/retry.sh python $SCRIPTS_DIR/sql/create_sql_user.py
       $SCRIPTS_DIR/retry.sh python $SCRIPTS_DIR/sql/load_csv_data.py

--- a/infrastructure/transform/locals.tf
+++ b/infrastructure/transform/locals.tf
@@ -15,7 +15,8 @@
 locals {
   sql_server_features_admin_username = "adminuser"
   sql_owner_app_name                 = "flowehr-sql-owner-${lower(var.naming_suffix)}"
-  databricks_app_name                = "flowehr-databricks-datawriter-${lower(var.naming_suffix)}"
+  databricks_adls_app_name           = "flowehr-databricks-adls-${lower(var.naming_suffix)}"
+  databricks_sql_app_name            = "flowehr-databricks-datawriter-${lower(var.naming_suffix)}"
   pipeline_file                      = "pipeline.json"
   trigger_file                       = "trigger.json"
   artifacts_dir                      = "artifacts"
@@ -95,7 +96,7 @@ locals {
   developers      = { "name" : var.developers_ad_group_display_name, "role" : "db_datareader" }
   data_scientists = { "name" : var.data_scientists_ad_group_display_name, "role" : "db_datareader" }
   apps            = { "name" : var.apps_ad_group_display_name, "role" : "db_datareader" }
-  databricks_app  = { "name" : local.databricks_app_name, "role" : "db_owner" }
+  databricks_app  = { "name" : local.databricks_sql_app_name, "role" : "db_owner" }
 
   real_data_users_groups = [
     local.apps,

--- a/infrastructure/transform/main.tf
+++ b/infrastructure/transform/main.tf
@@ -26,7 +26,7 @@ module "datalake" {
   zones                      = var.transform.datalake.zones
   adf_id                     = azurerm_data_factory.adf.id
   adf_identity_object_id     = azurerm_data_factory.adf.identity[0].principal_id
-  databricks_app_name        = "${local.databricks_app_name}-adls"
+  databricks_adls_app_name   = local.databricks_adls_app_name
   databricks_secret_scope_id = databricks_secret_scope.secrets.id
   tags                       = var.tags
 }

--- a/infrastructure/transform/main.tf
+++ b/infrastructure/transform/main.tf
@@ -26,7 +26,7 @@ module "datalake" {
   zones                      = var.transform.datalake.zones
   adf_id                     = azurerm_data_factory.adf.id
   adf_identity_object_id     = azurerm_data_factory.adf.identity[0].principal_id
-  databricks_app_name        = local.databricks_app_name
+  databricks_app_name        = "${local.databricks_app_name}-adls"
   databricks_secret_scope_id = databricks_secret_scope.secrets.id
   tags                       = var.tags
 }


### PR DESCRIPTION
# Resolves #316

## What is being addressed

Fixing the bug #316 by making sure the two service principals used to authenticate from Databricks have a different name. 

Additionally, fixing the `local-exec` swallowing errors when creating the users.
Additionally, fixing https://github.com/UCLH-Foundry/FlowEHR/issues/309 as a drive-by.
Additionally, fixing a dependency issue between Databricks workspace resource and `databricks_spark_version`. 

## Detailed explanation

In https://github.com/UCLH-Foundry/FlowEHR/pull/310, a bug was introduced: two service principals with the same name were created:

![image](https://github.com/UCLH-Foundry/FlowEHR/assets/52954123/699af9e3-6f6e-4eab-95b9-d431e8228e33)

Because of this, `create_sql_user.py` script was silently failing: it could not pick between two service principals with the same name when creating a user from an AAD account: 

![image](https://github.com/UCLH-Foundry/FlowEHR/assets/52954123/73aa1748-26be-40f1-8762-373df897eeb8)

Additionally, the `local-exec` block that was executing the script was not failing in this situation: 

![image](https://github.com/UCLH-Foundry/FlowEHR/assets/52954123/9d4ebe11-0474-4cfd-a658-0d4d21e56fed)
