### PR TITLE
Extract Spark configuration, secrets, init_scripts and libraries into the config

### DIFF
--- a/config.infra-test.yaml
+++ b/config.infra-test.yaml
@@ -14,10 +14,8 @@ transform:
       - Silver
       - Gold
   spark_config:
-    - key: spark.databricks.cluster.profile
-      value: singleNode
-    - key: spark.master
-      value: local[*]
+    spark.databricks.cluster.profile: singleNode
+    spark.master: local[*]
   databricks_libraries:
     pypi:
       - package: opencensus-ext-azure==1.1.9

--- a/config.infra-test.yaml
+++ b/config.infra-test.yaml
@@ -13,6 +13,15 @@ transform:
       - Bronze
       - Silver
       - Gold
+  spark_config:
+    - key: spark.databricks.cluster.profile
+      value: singleNode
+    - key: spark.master
+      value: local[*]
+  databricks_libraries:
+    pypi:
+      - opencensus-ext-azure==1.1.9
+      - opencensus-ext-logging==0.1.1
 
 serve:
   github_owner: UCLH-FlowEHR-TestBed

--- a/config.infra-test.yaml
+++ b/config.infra-test.yaml
@@ -20,8 +20,8 @@ transform:
       value: local[*]
   databricks_libraries:
     pypi:
-      - opencensus-ext-azure==1.1.9
-      - opencensus-ext-logging==0.1.1
+      - package: opencensus-ext-azure==1.1.9
+      - package: opencensus-ext-logging==0.1.1
 
 serve:
   github_owner: UCLH-FlowEHR-TestBed

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -43,6 +43,9 @@ transform:  # Optional
       - coordinates: "com.amazon.deequ:deequ:1.0.4"
         repo: "custom-mirror"
         exclusions: ["org.apache.avro:avro"]
+    cran:
+      - package: "rkeops"
+        repo: "my-awesome-repo"
     whl:
       - "dbfs:/FileStore/baz.whl"
     egg:

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -62,6 +62,9 @@ transform:  # Optional
       local_disk_min_size: 600
       category: "Memory Optimised"
     autotermination_minutes: 120
+    autoscale:
+      min_workers: 1
+      max_workers: 3
     init_scripts:
       - /workspaces/FlowEHR/transform/sample_init_script.sh
 

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -34,6 +34,9 @@ transform:  # Optional
       value: singleNode
     - key: spark.master
       value: local[*]
+  databricks_secrets:  # Optional
+    - key: cog_services_key
+      value: my-secret-key  # On Github, this wil lbe a token replacement
   databricks_libraries:  # Optional
     pypi:
       - package: opencensus-ext-azure==1.1.9
@@ -52,6 +55,8 @@ transform:  # Optional
       - "dbfs:/FileStore/foo.egg"
     jar:
       - "dbfs:/FileStore/app-0.0.1.jar"
+  init_scripts:
+    - /workspaces/FlowEHR/transform/sample_init_script.sh
 
 serve:  # Optional
   github_owner: A-GitHub-Org

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -30,13 +30,10 @@ transform:  # Optional
       - Silver
       - Gold
   spark_config:  # Optional
-    - key: spark.databricks.cluster.profile  # Configuration for a Single Node cluster
-      value: singleNode
-    - key: spark.master
-      value: local[*]
-  databricks_secrets:  # Optional
-    - key: cog_services_key
-      value: my-secret-key  # On Github, this wil lbe a token replacement
+    spark.databricks.cluster.profile: singleNode  # Configuration for a Single Node cluster
+    spark.master: local[*]
+  databricks_secrets:
+    cog_services_key: my-super-secret-key  # On Github, this wil lbe a token replacement
   databricks_libraries:  # Optional
     pypi:
       - package: opencensus-ext-azure==1.1.9

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -24,11 +24,20 @@ transform:  # Optional
     - url: https://github.com/MY_TRANSFORM_CODE_REPO.git
     - url: https://github.com/MY_OTHER_TRANSFORM_CODE_REPO.git
       sha: abcd01abcd01abcd01abcd01abcd01abcd01abcd
-  datalake:
+  datalake:  # Optional
     zones:
       - Bronze
       - Silver
       - Gold
+  spark_config:  # Optional
+    - key: spark.databricks.cluster.profile  # Configuration for a Single Node cluster
+      value: singleNode
+    - key: spark.master
+      value: local[*]
+  databricks_libraries:  # Optional
+    pypi:
+      - opencensus-ext-azure==1.1.9
+      - opencensus-ext-logging==0.1.1
 
 serve:  # Optional
   github_owner: A-GitHub-Org

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -55,8 +55,15 @@ transform:  # Optional
       - "dbfs:/FileStore/foo.egg"
     jar:
       - "dbfs:/FileStore/app-0.0.1.jar"
-  init_scripts:
-    - /workspaces/FlowEHR/transform/sample_init_script.sh
+  databricks_cluster:
+    node_type:
+      min_memory_gb: 128
+      min_cores: 16
+      local_disk_min_size: 600
+      category: "Memory Optimised"
+    autotermination_minutes: 120
+    init_scripts:
+      - /workspaces/FlowEHR/transform/sample_init_script.sh
 
 serve:  # Optional
   github_owner: A-GitHub-Org

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -46,13 +46,6 @@ transform:  # Optional
       - coordinates: "com.amazon.deequ:deequ:1.0.4"
         repo: "custom-mirror"
         exclusions: ["org.apache.avro:avro"]
-    cran:
-      - package: "rkeops"
-        repo: "my-awesome-repo"
-    whl:
-      - "dbfs:/FileStore/baz.whl"
-    egg:
-      - "dbfs:/FileStore/foo.egg"
     jar:
       - "dbfs:/FileStore/app-0.0.1.jar"
   databricks_cluster:

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -36,8 +36,19 @@ transform:  # Optional
       value: local[*]
   databricks_libraries:  # Optional
     pypi:
-      - opencensus-ext-azure==1.1.9
-      - opencensus-ext-logging==0.1.1
+      - package: opencensus-ext-azure==1.1.9
+      - package: opencensus-ext-logging==0.1.1
+        repo: "custom-mirror"
+    maven:
+      - coordinates: "com.amazon.deequ:deequ:1.0.4"
+        repo: "custom-mirror"
+        exclusions: ["org.apache.avro:avro"]
+    whl:
+      - "dbfs:/FileStore/baz.whl"
+    egg:
+      - "dbfs:/FileStore/foo.egg"
+    jar:
+      - "dbfs:/FileStore/app-0.0.1.jar"
 
 serve:  # Optional
   github_owner: A-GitHub-Org

--- a/infrastructure/transform/adf.tf
+++ b/infrastructure/transform/adf.tf
@@ -53,7 +53,7 @@ resource "azurerm_data_factory_linked_service_azure_databricks" "msi_linked" {
 
   msi_work_space_resource_id = azurerm_databricks_workspace.databricks.id
 
-  existing_cluster_id = databricks_cluster.fixed_single_node.cluster_id
+  existing_cluster_id = databricks_cluster.cluster.cluster_id
 }
 
 resource "azurerm_data_factory_linked_service_key_vault" "msi_linked" {

--- a/infrastructure/transform/databricks.tf
+++ b/infrastructure/transform/databricks.tf
@@ -70,6 +70,10 @@ resource "databricks_cluster" "cluster" {
   spark_version           = data.databricks_spark_version.latest.id
   node_type_id            = data.databricks_node_type.node_type.id
   autotermination_minutes = var.transform.databricks_cluster.autotermination_minutes
+  autoscale {
+    min_workers = var.transform.databricks_cluster.autoscale.min_workers
+    max_workers = var.transform.databricks_cluster.autoscale.max_workers
+  }
 
   spark_conf = merge(
     # Secrets for SQL Feature store

--- a/infrastructure/transform/databricks.tf
+++ b/infrastructure/transform/databricks.tf
@@ -65,7 +65,7 @@ data "databricks_node_type" "node_type" {
   depends_on = [time_sleep.wait_for_databricks_network]
 }
 
-resource "databricks_cluster" "fixed_single_node" {
+resource "databricks_cluster" "cluster" {
   cluster_name            = "Fixed Job Cluster"
   spark_version           = data.databricks_spark_version.latest.id
   node_type_id            = data.databricks_node_type.node_type.id
@@ -105,7 +105,7 @@ resource "databricks_cluster" "fixed_single_node" {
     }),
     # Additional secrets from the config
     tomap({ for secret in var.transform.databricks_secrets :
-      "spark.secret.${secret.key}" => "{{secrets/${databricks_secret_scope.secrets.name}/${secret.key}}}"
+      "spark.secret.${secret.name}" => "{{secrets/${databricks_secret_scope.secrets.name}/${secret.name}}}"
     }),
     # Any values set in the config
     tomap({ for config_value in var.transform.spark_config :

--- a/infrastructure/transform/databricks.tf
+++ b/infrastructure/transform/databricks.tf
@@ -128,8 +128,40 @@ resource "databricks_cluster" "fixed_single_node" {
     content {
       maven {
         coordinates = library.value.coordinates
+        repo        = library.value.repo
         exclusions  = library.value.exclusions
       }
+    }
+  }
+
+  dynamic "library" {
+    for_each = var.transform.databricks_libraries.cran
+    content {
+      cran {
+        package = library.value.package
+        repo    = library.value.repo
+      }
+    }
+  }
+
+  dynamic "library" {
+    for_each = var.transform.databricks_libraries.whl
+    content {
+      whl = library.value
+    }
+  }
+
+  dynamic "library" {
+    for_each = var.transform.databricks_libraries.egg
+    content {
+      egg = library.value
+    }
+  }
+
+  dynamic "library" {
+    for_each = var.transform.databricks_libraries.jar
+    content {
+      jar = library.value
     }
   }
 

--- a/infrastructure/transform/databricks.tf
+++ b/infrastructure/transform/databricks.tf
@@ -108,13 +108,11 @@ resource "databricks_cluster" "cluster" {
       "spark.secret.${connection.name}-password" => "{{secrets/${databricks_secret_scope.secrets.name}/flowehr-dbks-${connection.name}-password}}"
     }),
     # Additional secrets from the config
-    tomap({ for secret in var.transform.databricks_secrets :
-      "spark.secret.${secret.name}" => "{{secrets/${databricks_secret_scope.secrets.name}/${secret.name}}}"
+    tomap({ for secret_name, secret_value in var.transform.databricks_secrets :
+      "spark.secret.${secret_name}" => "{{secrets/${databricks_secret_scope.secrets.name}/${secret_name}}}"
     }),
     # Any values set in the config
-    tomap({ for config_value in var.transform.spark_config :
-      config_value.key => config_value.value
-    })
+    var.transform.spark_config
   )
 
   dynamic "library" {

--- a/infrastructure/transform/databricks.tf
+++ b/infrastructure/transform/databricks.tf
@@ -139,30 +139,6 @@ resource "databricks_cluster" "cluster" {
   }
 
   dynamic "library" {
-    for_each = var.transform.databricks_libraries.cran
-    content {
-      cran {
-        package = library.value.package
-        repo    = library.value.repo
-      }
-    }
-  }
-
-  dynamic "library" {
-    for_each = var.transform.databricks_libraries.whl
-    content {
-      whl = library.value
-    }
-  }
-
-  dynamic "library" {
-    for_each = var.transform.databricks_libraries.egg
-    content {
-      egg = library.value
-    }
-  }
-
-  dynamic "library" {
     for_each = var.transform.databricks_libraries.jar
     content {
       jar = library.value

--- a/infrastructure/transform/databricks.tf
+++ b/infrastructure/transform/databricks.tf
@@ -117,7 +117,18 @@ resource "databricks_cluster" "fixed_single_node" {
     for_each = var.transform.databricks_libraries.pypi
     content {
       pypi {
-        package = library.value
+        package = library.value.package
+        repo    = library.value.repo
+      }
+    }
+  }
+
+  dynamic "library" {
+    for_each = var.transform.databricks_libraries.maven
+    content {
+      maven {
+        coordinates = library.value.coordinates
+        exclusions  = library.value.exclusions
       }
     }
   }

--- a/infrastructure/transform/locals.tf
+++ b/infrastructure/transform/locals.tf
@@ -20,6 +20,8 @@ locals {
   pipeline_file                      = "pipeline.json"
   trigger_file                       = "trigger.json"
   artifacts_dir                      = "artifacts"
+  init_scripts_dir                   = "init_scripts"
+  cluster_logs_dir                   = "cluster_logs"
   adb_linked_service_name            = "ADBLinkedServiceViaMSI"
   dbfs_storage_account_name          = "dbfs${var.naming_suffix_truncated}"
   datalake_enabled                   = try(var.transform.datalake, null) != null

--- a/infrastructure/transform/secrets.tf
+++ b/infrastructure/transform/secrets.tf
@@ -70,3 +70,14 @@ resource "databricks_secret" "flowehr_databricks_sql_database" {
   string_value = azurerm_mssql_database.feature_database.name
   scope        = databricks_secret_scope.secrets.id
 }
+
+# Additional Databricks secrets passed in from the config
+resource "databricks_secret" "databricks_config_secret" {
+  for_each = { for secret in var.transform.databricks_secrets :
+    secret.key => secret.value
+  }
+
+  key          = each.key
+  string_value = each.value
+  scope        = databricks_secret_scope.secrets.id
+}

--- a/infrastructure/transform/secrets.tf
+++ b/infrastructure/transform/secrets.tf
@@ -73,9 +73,7 @@ resource "databricks_secret" "flowehr_databricks_sql_database" {
 
 # Additional Databricks secrets passed in from the config
 resource "databricks_secret" "databricks_config_secret" {
-  for_each = { for secret in var.transform.databricks_secrets :
-    secret.name => secret.value
-  }
+  for_each = var.transform.databricks_secrets
 
   key          = each.key
   string_value = each.value

--- a/infrastructure/transform/secrets.tf
+++ b/infrastructure/transform/secrets.tf
@@ -74,7 +74,7 @@ resource "databricks_secret" "flowehr_databricks_sql_database" {
 # Additional Databricks secrets passed in from the config
 resource "databricks_secret" "databricks_config_secret" {
   for_each = { for secret in var.transform.databricks_secrets :
-    secret.key => secret.value
+    secret.name => secret.value
   }
 
   key          = each.key

--- a/infrastructure/transform/variables.tf
+++ b/infrastructure/transform/variables.tf
@@ -114,9 +114,9 @@ variable "transform" {
     spark_config = optional(list(object({
       key   = string,
       value = string
-    })), []),
+    })), [])
     databricks_secrets = optional(list(object({
-      key   = string,
+      name  = string,
       value = string,
     })), [])
     databricks_libraries = optional(object({

--- a/infrastructure/transform/variables.tf
+++ b/infrastructure/transform/variables.tf
@@ -136,8 +136,17 @@ variable "transform" {
         package = string,
         repo    = optional(string)
       })), [])
+    }), {}),
+    databricks_cluster = optional(object({
+      node_type = optional(object({
+        min_memory_gb       = optional(number, 0),
+        min_cores           = optional(number, 0),
+        local_disk_min_size = optional(number, 0),
+        category            = optional(string, "")
+      }), {}),
+      autotermination_minutes = optional(number, 0),
+      init_scripts            = optional(list(string), [])
     }), {})
-    init_scripts = optional(list(string), [])
   })
   default = {
     spark_version = "3.3"

--- a/infrastructure/transform/variables.tf
+++ b/infrastructure/transform/variables.tf
@@ -115,6 +115,10 @@ variable "transform" {
       key   = string,
       value = string
     })), []),
+    databricks_secrets = optional(list(object({
+      key   = string,
+      value = string,
+    })), [])
     databricks_libraries = optional(object({
       whl = optional(list(string), []),
       egg = optional(list(string), []),
@@ -131,8 +135,9 @@ variable "transform" {
       cran = optional(list(object({
         package = string,
         repo    = optional(string)
-      })))
+      })), [])
     }), {})
+    init_scripts = optional(list(string), [])
   })
   default = {
     spark_version = "3.3"

--- a/infrastructure/transform/variables.tf
+++ b/infrastructure/transform/variables.tf
@@ -116,7 +116,22 @@ variable "transform" {
       value = string
     })), []),
     databricks_libraries = optional(object({
-      pypi = optional(list(string), [])
+      whl = optional(list(string), []),
+      egg = optional(list(string), []),
+      jar = optional(list(string), []),
+      pypi = optional(list(object({
+        package = string,
+        repo    = optional(string)
+      })), []),
+      maven = optional(list(object({
+        coordinates = string,
+        repo        = optional(string),
+        exclusions  = optional(list(string), [])
+      })), []),
+      cran = optional(list(object({
+        package = string,
+        repo    = optional(string)
+      })))
     }), {})
   })
   default = {

--- a/infrastructure/transform/variables.tf
+++ b/infrastructure/transform/variables.tf
@@ -120,8 +120,6 @@ variable "transform" {
       value = string,
     })), [])
     databricks_libraries = optional(object({
-      whl = optional(list(string), []),
-      egg = optional(list(string), []),
       jar = optional(list(string), []),
       pypi = optional(list(object({
         package = string,
@@ -131,10 +129,6 @@ variable "transform" {
         coordinates = string,
         repo        = optional(string),
         exclusions  = optional(list(string), [])
-      })), []),
-      cran = optional(list(object({
-        package = string,
-        repo    = optional(string)
       })), [])
     }), {}),
     databricks_cluster = optional(object({

--- a/infrastructure/transform/variables.tf
+++ b/infrastructure/transform/variables.tf
@@ -111,14 +111,8 @@ variable "transform" {
     datalake = optional(object({
       zones = set(string)
     }))
-    spark_config = optional(list(object({
-      key   = string,
-      value = string
-    })), [])
-    databricks_secrets = optional(list(object({
-      name  = string,
-      value = string,
-    })), [])
+    spark_config       = optional(map(string), {})
+    databricks_secrets = optional(map(string), {})
     databricks_libraries = optional(object({
       jar = optional(list(string), []),
       pypi = optional(list(object({

--- a/infrastructure/transform/variables.tf
+++ b/infrastructure/transform/variables.tf
@@ -146,6 +146,10 @@ variable "transform" {
       }), {}),
       autotermination_minutes = optional(number, 0),
       init_scripts            = optional(list(string), [])
+      autoscale = optional(object({
+        min_workers = optional(number, 0)
+        max_workers = optional(number, 0)
+      }), {})
     }), {})
   })
   default = {

--- a/infrastructure/transform/variables.tf
+++ b/infrastructure/transform/variables.tf
@@ -111,6 +111,13 @@ variable "transform" {
     datalake = optional(object({
       zones = set(string)
     }))
+    spark_config = optional(list(object({
+      key   = string,
+      value = string
+    })), []),
+    databricks_libraries = optional(object({
+      pypi = optional(list(string), [])
+    }), {})
   })
   default = {
     spark_version = "3.3"


### PR DESCRIPTION
## What is being addressed

Extract Spark configuration and libraries into a separate section of the config.

## How is this addressed

- Add `spark_config` section to the config and move the single-node configuration there 
- Add `databricks_libraries` section to the config and propagate all types of libraries supported by databricks terraform provider: https://registry.terraform.io/providers/databricks/databricks/0.4.2/docs/resources/cluster#library-configuration-block 
- Add `databricks_cluster` section to be able to configure the size of the cluster
- Add `init_scripts` section to the config and upload a dbfs file from local filesystem
- Add `databricks_secrets` section to the config and create corresponding secrets in the secret scope
