### PR TITLE
Databricks cluster customisation: Add singleNode mode and fixed node options

### DIFF
--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -30,8 +30,7 @@ transform:  # Optional
       - Silver
       - Gold
   spark_config:  # Optional
-    spark.databricks.cluster.profile: singleNode  # Configuration for a Single Node cluster
-    spark.master: local[*]
+    spark.configuration.key: value
   databricks_secrets:
     cog_services_key: my-super-secret-key  # On Github, this wil lbe a token replacement
   databricks_libraries:  # Optional
@@ -52,6 +51,7 @@ transform:  # Optional
       local_disk_min_size: 600
       category: "Memory Optimised"
     autotermination_minutes: 120
+    num_of_workers: 0  # Set to 0 for single node mode or any number for fixed cluster (ignored if autoscale also defined)
     autoscale:
       min_workers: 1
       max_workers: 3

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -51,7 +51,7 @@ transform:  # Optional
       local_disk_min_size: 600
       category: "Memory Optimised"
     autotermination_minutes: 120
-    runtime_engine: STANDARD  # Optional: STANDARD or PHOTON
+    runtime_engine: STANDARD  # Optional: STANDARD or PHOTON (https://learn.microsoft.com/en-us/azure/databricks/runtime/photon)
     num_of_workers: 0  # Set to 0 for single node mode or any number for fixed cluster (ignored if autoscale also defined)
     autoscale:
       min_workers: 1

--- a/config.sample.yaml
+++ b/config.sample.yaml
@@ -51,6 +51,7 @@ transform:  # Optional
       local_disk_min_size: 600
       category: "Memory Optimised"
     autotermination_minutes: 120
+    runtime_engine: STANDARD  # Optional: STANDARD or PHOTON
     num_of_workers: 0  # Set to 0 for single node mode or any number for fixed cluster (ignored if autoscale also defined)
     autoscale:
       min_workers: 1

--- a/infrastructure/transform/databricks.tf
+++ b/infrastructure/transform/databricks.tf
@@ -57,10 +57,12 @@ data "databricks_spark_version" "latest" {
 }
 
 data "databricks_node_type" "node_type" {
-  min_memory_gb       = var.transform.databricks_cluster.node_type.min_memory_gb
-  min_cores           = var.transform.databricks_cluster.node_type.min_cores
-  local_disk_min_size = var.transform.databricks_cluster.node_type.local_disk_min_size
-  category            = var.transform.databricks_cluster.node_type.category
+  min_memory_gb         = var.transform.databricks_cluster.node_type.min_memory_gb
+  min_cores             = var.transform.databricks_cluster.node_type.min_cores
+  local_disk_min_size   = var.transform.databricks_cluster.node_type.local_disk_min_size
+  category              = var.transform.databricks_cluster.node_type.category
+  photon_worker_capable = var.transform.databricks_cluster.runtime_engine == "PHOTON"
+  photon_driver_capable = var.transform.databricks_cluster.runtime_engine == "PHOTON"
 
   depends_on = [time_sleep.wait_for_databricks_network]
 }
@@ -71,6 +73,7 @@ resource "databricks_cluster" "cluster" {
   node_type_id            = data.databricks_node_type.node_type.id
   autotermination_minutes = var.transform.databricks_cluster.autotermination_minutes
   num_workers             = !local.autoscale_cluster ? var.transform.databricks_cluster.num_of_workers : null
+  runtime_engine          = var.transform.databricks_cluster.runtime_engine
 
   dynamic "autoscale" {
     for_each = local.autoscale_cluster ? [1] : []

--- a/infrastructure/transform/locals.tf
+++ b/infrastructure/transform/locals.tf
@@ -25,6 +25,8 @@ locals {
   adb_linked_service_name            = "ADBLinkedServiceViaMSI"
   dbfs_storage_account_name          = "dbfs${var.naming_suffix_truncated}"
   datalake_enabled                   = try(var.transform.datalake, null) != null
+  autoscale_cluster                  = var.transform.databricks_cluster.autoscale != null
+  single_node                        = !local.autoscale_cluster && var.transform.databricks_cluster.num_of_workers == 0
 
   # IPs required for Databricks UDRs 
   # Built from https://learn.microsoft.com/en-us/azure/databricks/resources/supported-regions#--control-plane-nat-webapp-and-extended-infrastructure-ip-addresses-and-domains

--- a/infrastructure/transform/variables.tf
+++ b/infrastructure/transform/variables.tf
@@ -108,11 +108,14 @@ variable "transform" {
       url = string,
       sha = optional(string, "")
     })), [])
+
     datalake = optional(object({
       zones = set(string)
     }))
+
     spark_config       = optional(map(string), {})
     databricks_secrets = optional(map(string), {})
+
     databricks_libraries = optional(object({
       jar = optional(list(string), []),
       pypi = optional(list(object({
@@ -125,6 +128,7 @@ variable "transform" {
         exclusions  = optional(list(string), [])
       })), [])
     }), {}),
+
     databricks_cluster = optional(object({
       node_type = optional(object({
         min_memory_gb       = optional(number, 0),
@@ -132,12 +136,15 @@ variable "transform" {
         local_disk_min_size = optional(number, 0),
         category            = optional(string, "")
       }), {}),
+
       autotermination_minutes = optional(number, 0),
       init_scripts            = optional(list(string), [])
+      num_of_workers          = optional(number, 0)
+
       autoscale = optional(object({
         min_workers = optional(number, 0)
         max_workers = optional(number, 0)
-      }), {})
+      }), null)
     }), {})
   })
   default = {

--- a/infrastructure/transform/variables.tf
+++ b/infrastructure/transform/variables.tf
@@ -139,6 +139,7 @@ variable "transform" {
 
       autotermination_minutes = optional(number, 0),
       init_scripts            = optional(list(string), [])
+      runtime_engine          = optional(string, "STANDARD")
       num_of_workers          = optional(number, 0)
 
       autoscale = optional(object({


### PR DESCRIPTION
### Resolves #283 

## What is being addressed

Previously when adding an `autoscale` block and specifying a number of workers, the custom tags for single node were preventing autoscaling from happening, meaning you could not actually customise the cluster node number. This restriction has been removed.

## How is this addressed

- Added a `num_of_workers` field to the transform config allowing fixed sizes to be specified as well as `0` for `singleNode` mode
- If `0` is specified, we add the necessary spark config and custom tags automatically
- If `autoscale` is specified, any `num_of_workers` setting is ignored and the cluster is configured with autoscale enabled (without the singleNode custom tag as was previously set regardless)
- Also added ability to set `runtime_engine` to either `STANDARD` or `PHOTON` for performance boost