### PR TITLE
Added missing azure-tenant-id secret to databricks

### DIFF
--- a/infrastructure/transform/databricks.tf
+++ b/infrastructure/transform/databricks.tf
@@ -98,6 +98,7 @@ resource "databricks_cluster" "cluster" {
     }),
     # Secrets for FlowEHR External app
     tomap({
+      "spark.secret.azure-tenant-id"               = "{{secrets/${databricks_secret_scope.secrets.name}/${databricks_secret.external_connection_azure_tenant_id.key}}}"
       "spark.secret.external-connection-app-id"    = "{{secrets/${databricks_secret_scope.secrets.name}/${databricks_secret.external_connection_spn_app_id.key}}}"
       "spark.secret.exernal-connection-app-secret" = "{{secrets/${databricks_secret_scope.secrets.name}/${databricks_secret.external_connection_spn_app_secret.key}}}"
     }),

--- a/infrastructure/transform/secrets.tf
+++ b/infrastructure/transform/secrets.tf
@@ -72,6 +72,12 @@ resource "databricks_secret" "flowehr_databricks_sql_database" {
 }
 
 # FlowEHR external app secrets
+resource "databricks_secret" "external_connection_azure_tenant_id" {
+  key          = "flowehr-azure-tenant-id"
+  string_value = azuread_service_principal.flowehr_external_connection.application_tenant_id
+  scope        = databricks_secret_scope.secrets.id
+}
+
 resource "databricks_secret" "external_connection_spn_app_id" {
   key          = "flowehr-external-connection-app-id"
   string_value = azuread_service_principal.flowehr_external_connection.application_id


### PR DESCRIPTION
Found `azure-tenant-id` was expected in pipeline code, but missing from databricks secrets. This adds it in.