### PR TITLE
Fixed mismatch of DNS zones for unity metastore private links

### DIFF
--- a/infrastructure/transform/unity-catalog-metastore/metastore.tf
+++ b/infrastructure/transform/unity-catalog-metastore/metastore.tf
@@ -61,8 +61,8 @@ resource "azurerm_storage_account" "unity_catalog" {
 # in this module
 resource "azurerm_private_endpoint" "metastore_pe" {
   for_each = {
-    "dfs"  = var.private_dns_zones["blob"].id
-    "blob" = var.private_dns_zones["dfs"].id
+    "dfs"  = var.private_dns_zones["dfs"].id
+    "blob" = var.private_dns_zones["blob"].id
   }
   name                = "pe-uc-${each.key}-${lower(var.naming_suffix)}"
   location            = data.azurerm_resource_group.core_rg.location

--- a/infrastructure/transform/unity-catalog/network.tf
+++ b/infrastructure/transform/unity-catalog/network.tf
@@ -16,8 +16,8 @@
 # If the metastore is created as part of this deployment, the private endpoint will already be created
 resource "azurerm_private_endpoint" "metastore_storage" {
   for_each = var.metastore_created ? {} : {
-    "dfs"  = var.private_dns_zones["blob"].id
-    "blob" = var.private_dns_zones["dfs"].id
+    "dfs"  = var.private_dns_zones["dfs"].id
+    "blob" = var.private_dns_zones["blob"].id
   }
 
   name                = "pe-uc-${each.key}-${var.naming_suffix}"


### PR DESCRIPTION
# Resolves #332 

## What is being addressed

Fixes the DNS mismatch causing storage communication errors

