### PR TITLE
Rename predefined metric

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -36,7 +36,10 @@
 		"ghcr.io/stuartleeks/dev-container-features/shell-history:0": {},
 		"ghcr.io/devcontainers-contrib/features/pre-commit:2": {},
 		"ghcr.io/lukewiwa/features/shellcheck:0": {},
-		"ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {},
+		"ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {
+			"jqVersion": "latest",
+			"yqVersion": "latest"
+		},
 		"ghcr.io/jlaundry/devcontainer-features/mssql-odbc-driver:1": {
 			"version": "18"
 		},

--- a/infrastructure/transform/locals.tf
+++ b/infrastructure/transform/locals.tf
@@ -123,4 +123,6 @@ locals {
   ]
 
   sql_users_to_create = var.accesses_real_data ? local.real_data_users_groups : local.synth_data_users_groups
+
+  predefined_metric_name = "rows_updated"
 }

--- a/infrastructure/transform/monitoring.tf
+++ b/infrastructure/transform/monitoring.tf
@@ -188,11 +188,11 @@ resource "azurerm_portal_dashboard" "pipeline_status_dashboard" {
                           "resourceMetadata": {
                             "id": "${azurerm_application_insights.transform.id}"
                           },
-                          "name": "${each.key}/rows_inserted",
+                          "name": "${each.key}/${local.predefined_metric_name}",
                           "aggregationType": 4,
-                          "namespace": "${each.key}/rows_inserted",
+                          "namespace": "${each.key}/${local.predefined_metric_name}",
                           "metricVisualization": {
-                            "displayName": "${each.key}/rows_inserted"
+                            "displayName": "${each.key}/${local.predefined_metric_name}"
                           }
                         }
                       ],


### PR DESCRIPTION
# Resolves _#ISSUE_

## What is being addressed

Small refactoring: Rename pre-defined metric expected in the dashboard from `rows_inserted` to `rows_updated` to reflect that rows can be inserted, updated and deleted.